### PR TITLE
6 comma separation in declaration statements

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -298,7 +298,7 @@ pub const WhileStmt = struct {
 pub const Stmt = union(enum) {
     DeclareStmt: []const *const Expr,
     ExprStmt: *const Expr,
-    PrintStmt: *const Expr,
+    PrintStmt: []const *const Expr,
     BlockStmt: []const Stmt,
     IfElseStmt: *const IfElseStmt,
     WhileStmt: *const WhileStmt,
@@ -312,7 +312,10 @@ pub const Stmt = union(enum) {
                 allocator.free(exprs);
             },
             .ExprStmt => |expr| expr.destroyAll(allocator),
-            .PrintStmt => |expr| expr.destroyAll(allocator),
+            .PrintStmt => |exprs| {
+                for (exprs) |expr| expr.destroyAll(allocator);
+                allocator.free(exprs);
+            },
             .BlockStmt => |stmts| {
                 for (stmts) |stmt| stmt.destroyAll(allocator);
                 allocator.free(stmts);
@@ -339,7 +342,11 @@ pub const Stmt = union(enum) {
                 try writer.print("\n", .{});
             },
             .ExprStmt => |expr| try writer.print("{}\n", .{expr}),
-            .PrintStmt => |expr| try writer.print("PRINT {}\n", .{expr}),
+            .PrintStmt => |exprs| {
+                try writer.print("PRINT ", .{});
+                for (exprs) |expr| try writer.print("{}, ", .{expr});
+                try writer.print("\n", .{});
+            },
             .BlockStmt => |stmts| {
                 try writer.print("BEGIN BLOCK\n", .{});
                 for (stmts) |stmt| try writer.print("{}\n", .{stmt});

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -246,12 +246,14 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
 
             return StmtReturn {.NoReturn = {}};
         },
-        .PrintStmt => |expr| {
-
-            // Evaluate expression and print resulting literal
-            // TODO: Use parameterized writer and remove unreachable
-            const res: ast.Lit = try evalExpr(expr, env);
-            std.io.getStdOut().writer().print("{}\n", .{res}) catch unreachable;
+        .PrintStmt => |exprs| {
+            for (exprs) |expr| {
+                // Evaluate expression and print resulting literal
+                // TODO: Use parameterized writer and remove unreachable
+                const res: ast.Lit = try evalExpr(expr, env);
+                std.io.getStdOut().writer().print("{} ", .{res}) catch unreachable;
+            }
+            std.io.getStdOut().writer().print("\n", .{}) catch unreachable;
             return StmtReturn {.NoReturn = {}};
         },
         .BlockStmt => |stmts| {

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -14,7 +14,7 @@ fn createLU(comptime chars: []const u8) [256]bool {
 const is_numeric_digit: [256]bool = createLU("0123456789");
 const is_real_digit: [256]bool = createLU(".0123456789");
 const is_whitespace_digit: [256]bool = createLU(" \t\r");
-const is_operator_digit: [256]bool = createLU("+-/*|&()[]{}=!<>\n");
+const is_operator_digit: [256]bool = createLU("+-/*|&()[]{}=!<>\n,");
 const is_ident_digit: [256]bool = createLU(
     "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 );
@@ -26,7 +26,7 @@ fn contains(arr: []const []const u8, item: []const u8) bool {
 
 fn is_operator(chars: []const u8) bool {
     return contains(
-        &[_][]const u8 { "\n", "+", "-", "*", "/", "!", "||", "&&", "==", "=", "(", ")", "[", "]", "{", "}", "<", ">", "<=", ">="},
+        &[_][]const u8 { "\n", "+", "-", "*", "/", "!", "||", "&&", "==", "=", "(", ")", "[", "]", "{", "}", "<", ">", "<=", ">=", ","},
         chars
     );
 }
@@ -51,6 +51,7 @@ fn operator_from_string(str: []const u8) token.Token {
     if (std.mem.eql(u8, str, ">")) return token.Token {.GT = {}};
     if (std.mem.eql(u8, str, "<=")) return token.Token {.LTE = {}};
     if (std.mem.eql(u8, str, ">=")) return token.Token {.GTE = {}};
+    if (std.mem.eql(u8, str, ",")) return token.Token {.COMMA = {}};
     if (std.mem.eql(u8, str, "\n")) return token.Token {.LB = {}};
     unreachable;
 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -203,10 +203,20 @@ pub const Parser = struct {
             },
             .DECLARE => {
                 try self.expectToken(Token {.DECLARE = {}});
-                const exp: *ast.Expr = try self.parseExpr();
-                errdefer exp.destroyAll(self.allocator);
+
+                var acc: ArrayList(*ast.Expr) = .init(self.allocator);
+                defer acc.deinit();
+                errdefer for (acc.items) |expr| expr.destroyAll(self.allocator);
+
+                acc.append(try self.parseExpr()) catch unreachable;
+
+                while (std.meta.eql(self.peekToken(), Token {.COMMA = {}})) {
+                    try self.expectToken(Token {.COMMA = {}});
+                    acc.append(try self.parseExpr()) catch unreachable;
+                }
+
                 try self.expectTokenOrEOF(Token {.LB = {}});
-                break :blk ast.Stmt {.DeclareStmt = exp};
+                break :blk ast.Stmt {.DeclareStmt = acc.toOwnedSlice() catch unreachable};
             },
             .IF => {
                 try self.expectToken(Token {.IF = {}});

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -196,10 +196,19 @@ pub const Parser = struct {
             // Statements that start with specific keywords
             .PRINT => {
                 try self.expectToken(Token {.PRINT = {}});
-                const exp: *ast.Expr = try self.parseExpr();
-                errdefer exp.destroyAll(self.allocator);
+
+                var acc: ArrayList(*ast.Expr) = .init(self.allocator);
+                defer acc.deinit();
+                errdefer for (acc.items) |expr| expr.destroyAll(self.allocator);
+
+                acc.append(try self.parseExpr()) catch unreachable;
+                while (std.meta.eql(self.peekToken(), Token {.COMMA = {}})) {
+                    try self.expectToken(Token {.COMMA = {}});
+                    acc.append(try self.parseExpr()) catch unreachable;
+                }
+
                 try self.expectTokenOrEOF(Token {.LB = {}});
-                break :blk ast.Stmt {.PrintStmt = exp};
+                break :blk ast.Stmt {.PrintStmt = acc.toOwnedSlice() catch unreachable};
             },
             .DECLARE => {
                 try self.expectToken(Token {.DECLARE = {}});
@@ -209,7 +218,6 @@ pub const Parser = struct {
                 errdefer for (acc.items) |expr| expr.destroyAll(self.allocator);
 
                 acc.append(try self.parseExpr()) catch unreachable;
-
                 while (std.meta.eql(self.peekToken(), Token {.COMMA = {}})) {
                     try self.expectToken(Token {.COMMA = {}});
                     acc.append(try self.parseExpr()) catch unreachable;

--- a/src/tests/interpreter.zig
+++ b/src/tests/interpreter.zig
@@ -232,14 +232,14 @@ test "smart scoped assignment" {
                     .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
                     .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 20}},
                 }}},
-                ast.Stmt {.PrintStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+                ast.Stmt {.PrintStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
             }},
             .elseStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-                ast.Stmt {.PrintStmt = &ast.Expr {.Lit = ast.Lit {.Int = 1}}}
+                ast.Stmt {.PrintStmt = &[_]*const ast.Expr {&ast.Expr {.Lit = ast.Lit {.Int = 1}}}}
             }}
         }},
 
-        ast.Stmt {.PrintStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+        ast.Stmt {.PrintStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
     }};
 
     // Evaluate statement to error for z
@@ -275,14 +275,14 @@ test "smart scoped declaration" {
                     .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
                     .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 20}},
                 }}}},
-                ast.Stmt {.PrintStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+                ast.Stmt {.PrintStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
             }},
             .elseStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-                ast.Stmt {.PrintStmt = &ast.Expr {.Lit = ast.Lit {.Int = 1}}}
+                ast.Stmt {.PrintStmt = &[_]*const ast.Expr {&ast.Expr {.Lit = ast.Lit {.Int = 1}}}}
             }}
         }},
 
-        ast.Stmt {.PrintStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+        ast.Stmt {.PrintStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
     }};
 
     // Evaluate statement to error for z

--- a/src/tests/interpreter.zig
+++ b/src/tests/interpreter.zig
@@ -117,7 +117,9 @@ test "let x (= undefined)" {
     defer env.deinit();
 
     // Prepare statement
-    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}};
+    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
+        &ast.Expr {.Lval = ast.Lval {.Var = "x"}}
+    }};
 
     // Evaluate statement
     _ = try interpreter.evalStmt(stmt, &env);
@@ -135,10 +137,12 @@ test "let x = 49" {
     defer env.deinit();
 
     // Prepare statement
-    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
-        .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
-        .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 49}}
-    }}};
+    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
+        &ast.Expr {.AssignExpr = ast.AssignExpr {
+            .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+            .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 49}}
+        }}
+    }};
 
     // Evaluate statement
     _ = try interpreter.evalStmt(stmt, &env);
@@ -156,12 +160,14 @@ test "invalid chain declaration" {
     defer env.deinit();
 
     // Prepare statement
-    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
-        .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
-        .rhs = &ast.Expr {.AssignExpr = ast.AssignExpr {
-            .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "y"}},
-            .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 19}}
-        }}
+    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
+        &ast.Expr {.AssignExpr = ast.AssignExpr {
+            .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+            .rhs = &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "y"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 19}}
+            }}
+        }
     }}};
 
     // Evaluate statement to error for z
@@ -177,9 +183,10 @@ test "redeclaration error" {
     defer env.deinit();
 
     // Prepare statement
-    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
         .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
         .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
+        }
     }}};
 
     // Evaluate statement to error for z
@@ -194,7 +201,7 @@ test "redeclaration error 2" {
     defer env.deinit();
 
     // Prepare statement
-    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}};
+    const stmt: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}};
 
     // Evaluate statement to error for z
     const err: interpreter.EvalError!interpreter.StmtReturn = interpreter.evalStmt(stmt, &env);
@@ -209,10 +216,10 @@ test "smart scoped assignment" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.IfElseStmt = &ast.IfElseStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -252,10 +259,10 @@ test "smart scoped declaration" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.IfElseStmt = &ast.IfElseStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -264,10 +271,10 @@ test "smart scoped declaration" {
                 .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}},
             }},
             .ifStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-                ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+                ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
                     .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
                     .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 20}},
-                }}},
+                }}}},
                 ast.Stmt {.PrintStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
             }},
             .elseStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
@@ -391,10 +398,10 @@ test "break works" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -440,10 +447,10 @@ test "break in block works" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -493,14 +500,14 @@ test "continue works" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        }}}},
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "y"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 0}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -546,14 +553,14 @@ test "continue in block works" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        }}}},
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "y"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 0}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -673,4 +680,37 @@ test "continue outside error 2" {
         res,
         interpreter.EvalError.UnexpectedContinue
     );
+}
+
+test "comma declaration" {
+    // Prepare environment
+    var env = venv.Env.new(std.testing.allocator);
+    defer env.deinit();
+
+    // Prepare procedure
+    const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
+
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
+            &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
+            }},
+            &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "y"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 2}}
+            }},
+            &ast.Expr {.Lval = ast.Lval {.Var = "z"}},
+            &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "w"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
+            }},
+        }},
+    }};
+
+    // Evaluate statement to error for z
+    _ = try interpreter.evalProc(proc, &env);
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 1}}, env.lookup("x"));
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 2}}, env.lookup("y"));
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Undefined = {}}}, env.lookup("z"));
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 1}}, env.lookup("w"));
 }

--- a/src/tests/lexer.zig
+++ b/src/tests/lexer.zig
@@ -1446,3 +1446,35 @@ test "newline block break" {
 
     try std.testing.expectEqualDeep(expected, tokens.items);
 }
+
+
+test "comma declaration" {
+    const input =
+        \\declare x = 1, y = 2, z, w = 5
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.DECLARE = {}},
+        Token {.IDENT = "x"},
+        Token {.EQ = {}},
+        Token {.INTLIT = 1},
+        Token {.COMMA = {}},
+        Token {.IDENT = "y"},
+        Token {.EQ = {}},
+        Token {.INTLIT = 2},
+        Token {.COMMA = {}},
+        Token {.IDENT = "z"},
+        Token {.COMMA = {}},
+        Token {.IDENT = "w"},
+        Token {.EQ = {}},
+        Token {.INTLIT = 5},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}

--- a/src/tests/parser.zig
+++ b/src/tests/parser.zig
@@ -735,9 +735,9 @@ test "declare statement" {
     const result: ast.Stmt = try prs.parseStmt();
     defer result.destroyAll(std.testing.allocator);
 
-    const expect: ast.Stmt = ast.Stmt {.DeclareStmt = &ast.Expr {
+    const expect: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {
         .Lval = ast.Lval {.Var = "x"}
-    }};
+    }}};
 
     try std.testing.expectEqualDeep(expect, result);
 }
@@ -842,7 +842,7 @@ test "block statement" {
     var prs: parser.Parser = .new(tokens, std.testing.allocator);
 
     const expect: ast.Stmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-        ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
     }};
 
     const actual: ast.Stmt = try prs.parseStmt();
@@ -874,9 +874,9 @@ test "nested block statement" {
     var prs: parser.Parser = .new(tokens, std.testing.allocator);
 
     const expect: ast.Stmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-        ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}},
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}},
         ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}},
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}},
         }}
     }};
 
@@ -907,8 +907,8 @@ test "if else statement" {
 
     const expect: ast.Stmt = ast.Stmt {.IfElseStmt = &ast.IfElseStmt {
         .cond = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
-        .ifStmt = ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}},
-        .elseStmt = ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "y"}}},
+        .ifStmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}},
+        .elseStmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "y"}}}},
     }};
 
     const actual: ast.Stmt = try prs.parseStmt();
@@ -947,10 +947,10 @@ test "if else block statement" {
     const expect: ast.Stmt = ast.Stmt {.IfElseStmt = &ast.IfElseStmt {
         .cond = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
         .ifStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
         }},
         .elseStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "y"}}}
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "y"}}}}
         }},
     }};
 
@@ -996,12 +996,12 @@ test "if else block statement 2" {
     const expect: ast.Stmt = ast.Stmt {.IfElseStmt = &ast.IfElseStmt {
         .cond = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
         .ifStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}},
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "y"}}}
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}},
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "y"}}}}
         }},
         .elseStmt = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "y"}}},
-            ast.Stmt {.DeclareStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}}
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "y"}}}},
+            ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.Lval = ast.Lval {.Var = "x"}}}}
         }},
     }};
 
@@ -1060,10 +1060,10 @@ test "complicated if-else branch" {
 
     const expect: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.IfElseStmt = &ast.IfElseStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -1122,10 +1122,10 @@ test "simple while with condition" {
 
     const expect: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr { &ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -1181,10 +1181,10 @@ test "more interesting while" {
 
     const expect: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -1245,10 +1245,10 @@ test "while with break statement" {
 
     const expect: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -1301,10 +1301,10 @@ test "while with continue statement" {
 
     const expect: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.DeclareStmt = &ast.Expr {.AssignExpr = ast.AssignExpr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {&ast.Expr {.AssignExpr = ast.AssignExpr {
             .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
             .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
-        }}},
+        }}}},
 
         ast.Stmt {.WhileStmt = &ast.WhileStmt {
             .cond = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
@@ -1315,6 +1315,55 @@ test "while with continue statement" {
             .body = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
                 ast.Stmt {.PrintStmt = &ast.Expr {.Lval = ast.Lval {.Var = "x"}}},
                 ast.Stmt {.ContinueStmt = {}},
+            }},
+        }},
+    }};
+
+    const actual: ast.Proc = try prs.parseProcedure();
+    defer actual.destroyAll(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(expect, actual);
+}
+
+
+test "comma declaration" {
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+
+
+    try tokens.append(Token {.DECLARE = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.EQ = {}});
+    try tokens.append(Token {.INTLIT = 1});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "y"});
+    try tokens.append(Token {.EQ = {}});
+    try tokens.append(Token {.INTLIT = 2});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "z"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "w"});
+    try tokens.append(Token {.EQ = {}});
+    try tokens.append(Token {.INTLIT = 1});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const expect: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
+
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
+            &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
+            }},
+            &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "y"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 2}}
+            }},
+            &ast.Expr {.Lval = ast.Lval {.Var = "z"}},
+            &ast.Expr {.AssignExpr = ast.AssignExpr {
+                .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "w"}},
+                .rhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
             }},
         }},
     }};

--- a/src/tests/parser.zig
+++ b/src/tests/parser.zig
@@ -1373,3 +1373,31 @@ test "comma declaration" {
 
     try std.testing.expectEqualDeep(expect, actual);
 }
+
+test "comma declaration double comma error" {
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+
+
+    try tokens.append(Token {.DECLARE = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.EQ = {}});
+    try tokens.append(Token {.INTLIT = 1});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "y"});
+    try tokens.append(Token {.EQ = {}});
+    try tokens.append(Token {.INTLIT = 2});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "z"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "w"});
+    try tokens.append(Token {.EQ = {}});
+    try tokens.append(Token {.INTLIT = 1});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+    const res: parser.ParseError!ast.Proc = prs.parseProcedure();
+
+    try std.testing.expectEqualDeep(res, parser.ParseError.ExpectedExpression);
+}

--- a/src/token.zig
+++ b/src/token.zig
@@ -31,6 +31,7 @@ pub const TokenType: type = enum {
     BREAK,
     CONTINUE,
     LB,
+    COMMA,
     EOF,
     ERROR,
     ILLEGAL
@@ -78,6 +79,7 @@ pub const Token: type = union(TokenType) {
 
     // Utility
     LB: void,
+    COMMA: void,
     EOF: void,
     ERROR: []const u8,
     ILLEGAL: u8,
@@ -93,6 +95,7 @@ pub const Token: type = union(TokenType) {
         switch (self) {
             .EOF      => try writer.print("[EOF     ]:", .{}),
             .LB       => try writer.print("[LB      ]:", .{}),
+            .COMMA    => try writer.print("[COMMA   ]:", .{}),
             .ERROR    => |val| try writer.print("[ERROR   ]: {s}", .{val}),
             .ILLEGAL  => |val| try writer.print("[ILLEGAL ]: {c}", .{val}),
             .LPAREN   => try writer.print("[LPAREN  ]:", .{}),


### PR DESCRIPTION
Implemented COMMA token and modifier parser and ast to support comma separation for `declare` and `print` statements:
```
declare x = 1, y, z = 20, w
print x, z, x < z, 4 - x * z
```