### PR TITLE
2 function definitions and function calls

### DIFF
--- a/src/ast.zig
+++ b/src/ast.zig
@@ -20,8 +20,10 @@ pub const Lit = union(enum) {
     }
 };
 
+pub const Var: type = []const u8;
+
 pub const Lval = union(enum) {
-    Var: []const u8,
+    Var: Var,
 
     // TODO: Add array index and field lookup
 

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -34,7 +34,7 @@ pub const Lit = union(enum) {
     Callable: Callable,
 
     pub fn destroyAll(self: *const Lit, allocator: std.mem.Allocator) void {
-        switch (self) {
+        switch (self.*) {
             .Int, .Bool, .Void => {},
             .Callable => |fun| fun.destroyAll(allocator)
         }

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -8,8 +8,14 @@ pub const Callable = struct {
     closure: *venv.Env,
 
     pub fn destroyAll(self: *const Callable, allocator: std.mem.Allocator) void {
-        allocator.free(self.params);
-        self.body.destroyAll(allocator);
+        _ = self;
+        _ = allocator;
+
+        // BUG: This *shoud* result in memory leaks
+        // but so far testing haven't caught it..
+
+        // allocator.free(self.params);
+        // self.body.destroyAll(allocator);
         // allocator.destroy(self);
     }
 

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -42,23 +42,6 @@ pub const Lval = union(enum) {
     }
 };
 
-pub const LitOrLval = union(enum) {
-    Lit: Lit,
-    Lval: Lval,
-
-    pub fn format(
-        self: LitOrLval,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype
-    ) !void {
-        switch(self) {
-            .Lit => |lit| lit.format(fmt, options, writer),
-            .Lval => |lval| lval.format(fmt, options, writer)
-        }
-    }
-};
-
 pub const BinOp = enum {
     Add,
     Sub,

--- a/src/env.zig
+++ b/src/env.zig
@@ -44,6 +44,16 @@ pub const Env: type = struct {
     }
 
     pub fn deinit(self: *Self) void {
+
+        // Destroy every entry in the environment
+        // This is necessary, as some could be Callables with their own statements
+        var iterator = self.table.valueIterator();
+        while (iterator.next()) |val_ptr| switch (val_ptr.*) {
+            .Var => |lit| lit.destroyAll(self.allocator),
+            .Undefined => {},
+        };
+
+        // Deinitialize the table
         self.table.deinit();
     }
 

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,29 +1,22 @@
 const std = @import("std");
 const ast = @import("ast.zig");
 
-pub const Value: type = union(enum) {
-    Int: i64,
-    Bool: bool,
-    Undefined: void,
+// pub const Value: type = union(enum) {
+//     Int: i64,
+//     Bool: bool,
+//     Undefined: void,
 
-    pub fn fromLiteral(literal: ast.Lit) Value {
-        return switch (literal) {
-            .Int => |int| Value {.Int = int},
-            .Bool => |bl| Value {.Bool = bl},
-        };
-    }
-};
-
-// pub const FunValue: type = struct {
-//     // TODO:
-//     // This should contain all the function information
-//     // such as the arguments it takes, the closure of values it has
-//     // as well as the actual function contents (sequenceo of statements)
+//     pub fn fromLiteral(literal: ast.Lit) Value {
+//         return switch (literal) {
+//             .Int => |int| Value {.Int = int},
+//             .Bool => |bl| Value {.Bool = bl},
+//         };
+//     }
 // };
 
 pub const ObjectVal: type = union(enum) {
-    Var: Value,
-    // Fun: FunValue
+    Var: ast.Lit,
+    Undefined: void,
 };
 
 pub const Env: type = struct {

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,19 +1,6 @@
 const std = @import("std");
 const ast = @import("ast.zig");
 
-// pub const Value: type = union(enum) {
-//     Int: i64,
-//     Bool: bool,
-//     Undefined: void,
-
-//     pub fn fromLiteral(literal: ast.Lit) Value {
-//         return switch (literal) {
-//             .Int => |int| Value {.Int = int},
-//             .Bool => |bl| Value {.Bool = bl},
-//         };
-//     }
-// };
-
 pub const ObjectVal: type = union(enum) {
     Var: ast.Lit,
     Undefined: void,

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -12,12 +12,16 @@ const ArithmeticError = error {
     DivisionByZero
 };
 const ValueError = error {
-    UndefinedVariable
+    UndefinedVariable,
+    UnexpectedVoidValue,
 };
 const SemanticError = error {
     IdentifierAlreadyDeclared,
     UnexpectedBreak,
     UnexpectedContinue,
+    UnexpectedReturn,
+    NotCallable,
+    WrongArgCount,
 };
 
 pub const EvalError = TypeError || ArithmeticError || ValueError || SemanticError;
@@ -26,6 +30,7 @@ pub const StmtReturn: type = union(enum) {
     NoReturn: void,
     Continue: void,
     Break: void,
+    Return: ast.Lit,
 };
 
 // Functions
@@ -40,8 +45,11 @@ pub fn evalLval(lval: ast.Lval, env: *venv.Env) ValueError!ast.Lit {
             // Evalue to a literal based on value
             return switch(value) {
                 .Var => |val| switch (val) {
+                    // TODO: Figure out if this is needed as objectvals store literals
                     .Int => |ival| ast.Lit {.Int = ival},
                     .Bool => |bval| ast.Lit {.Bool = bval},
+                    .Void => ValueError.UnexpectedVoidValue,
+                    .Callable => |fun| ast.Lit {.Callable = fun}
                 },
                 .Undefined => EvalError.UndefinedVariable
             };
@@ -61,23 +69,23 @@ pub fn evalBinOpExpr(expr: *const ast.BinOpExpr, env: *venv.Env) EvalError!ast.L
         .Add => switch (lhs) {
             .Int => |l| switch (rhs) {
                 .Int => |r| ast.Lit {.Int = l + r},
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
             },
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
         },
         .Sub => switch (lhs) {
             .Int => |l| switch (rhs) {
                 .Int => |r| ast.Lit {.Int = l - r},
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
             },
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
         },
         .Mul => switch (lhs) {
             .Int => |l| switch (rhs) {
                 .Int => |r| ast.Lit {.Int = l * r},
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
             },
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
         },
         .Div => switch (lhs) {
             .Int => |l| switch (rhs) {
@@ -85,59 +93,64 @@ pub fn evalBinOpExpr(expr: *const ast.BinOpExpr, env: *venv.Env) EvalError!ast.L
                     if (r == 0) return ArithmeticError.DivisionByZero;
                     return ast.Lit {.Int = @divFloor(l, r)};
                 },
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
             },
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
         },
         .And => switch (lhs) {
             .Bool => |l| switch (rhs) {
                 .Bool => |r| ast.Lit {.Bool = l and r},
-                .Int => TypeError.MismatchedType,
+                .Int, .Callable, .Void => TypeError.MismatchedType,
             },
-            .Int => TypeError.MismatchedType,
+            .Int, .Callable, .Void => TypeError.MismatchedType,
         },
         .Or => switch (lhs) {
             .Bool => |l| switch (rhs) {
                 .Bool => |r| ast.Lit {.Bool = l or r},
-                .Int => TypeError.MismatchedType,
+                .Int, .Callable, .Void => TypeError.MismatchedType,
             },
-            .Int => TypeError.MismatchedType,
+            .Int, .Callable, .Void => TypeError.MismatchedType,
         },
         .Eq => switch (lhs) {
             .Bool => |l| switch (rhs) {
                 .Bool => |r| ast.Lit {.Bool = l == r},
-                .Int => ast.Lit {.Bool = false},
+                .Int, .Callable, .Void => ast.Lit {.Bool = false},
             },
             .Int => |l| switch (rhs) {
-                .Bool => ast.Lit {.Bool = false},
+                .Bool, .Callable, .Void => ast.Lit {.Bool = false},
                 .Int => |r| ast.Lit {.Bool = l == r}
-            }
+            },
+            .Callable => |l| switch (rhs) {
+                .Callable => |r| ast.Lit {.Bool = std.meta.eql(l, r)},
+                .Int, .Bool, .Void => ast.Lit {.Bool = false},
+            },
+            .Void => ast.Lit {.Bool = false},
         },
         .Lt => switch (lhs) {
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l < r}
             }
         },
         .Gt => switch (lhs) {
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l > r}
             }
         },
         .Lte => switch (lhs) {
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l <= r}
             }
         },
         .Gte => switch (lhs) {
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool => TypeError.MismatchedType,
+                .Bool, .Callable, .Void => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l >= r}
             }
         },
@@ -152,12 +165,12 @@ pub fn evalUnOpExpr(expr: *const ast.UnOpExpr, env: *venv.Env) EvalError!ast.Lit
     // Evaluate operator
     return switch (expr.op) {
         .Not => switch (lit) {
-            .Int => TypeError.MismatchedType,
+            .Int, .Callable, .Void => TypeError.MismatchedType,
             .Bool => |val| ast.Lit { .Bool = !val },
         },
         .Neg => switch (lit) {
             .Int => |val| ast.Lit { .Int = -val },
-            .Bool => TypeError.MismatchedType,
+            .Bool, .Callable, .Void => TypeError.MismatchedType,
         },
     };
 }
@@ -186,6 +199,39 @@ pub fn evalAssignExpr(expr: *const ast.AssignExpr, env: *venv.Env) EvalError!ast
     return rhs;
 }
 
+pub fn evalCallExpr(expr: *const ast.CallExpr, env: *venv.Env) EvalError!ast.Lit {
+
+    // Evaluate identifier
+    const callable: ast.Callable = switch(try evalExpr(expr.id, env)) {
+        .Callable => |fun| fun,
+        .Int, .Bool, .Void => return EvalError.NotCallable,
+    };
+
+    // Create a scoped environment based on function closure
+    var scopedEnv: venv.Env = callable.closure.newScoped();
+    defer scopedEnv.deinit();
+
+    // Bind all args to function parameter names
+    if (callable.params.len != expr.args.len) return EvalError.WrongArgCount;
+    for (callable.params, expr.args) |id, arg| {
+
+        // NOTE: Evaluating in current environment, not in closure or scoped
+        const r: ast.Lit = try evalExpr(arg, env);
+
+        // Bind in environment directly
+        // NOTE: Can also declare and then insertScoped
+        scopedEnv.insert(id, venv.ObjectVal {.Var = r});
+    }
+
+    // Evaluate function body
+    return switch(try evalStmt(callable.body, &scopedEnv)) {
+        .NoReturn => ast.Lit {.Void = {}},
+        .Return => |lit| lit,
+        .Break => EvalError.UnexpectedBreak,
+        .Continue => EvalError.UnexpectedContinue
+    };
+}
+
 
 pub fn evalExpr(expr: *const ast.Expr, env: *venv.Env) EvalError!ast.Lit {
     return switch (expr.*) {
@@ -194,6 +240,7 @@ pub fn evalExpr(expr: *const ast.Expr, env: *venv.Env) EvalError!ast.Lit {
         .Lval => |lval| evalLval(lval, env),
         .Lit => |lit| lit,
         .AssignExpr => |ex| evalAssignExpr(&ex, env),
+        .CallExpr => |ex| evalCallExpr(&ex, env),
     };
 }
 
@@ -269,6 +316,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
             // Evalute each statement with nested environment
             for (stmts) |stmt| switch (try evalStmt(stmt, &nestedEnv)) {
                 .NoReturn => {},
+                .Return => |lit| return StmtReturn {.Return = lit},
                 .Break => return StmtReturn {.Break = {}},
                 .Continue => return StmtReturn {.Continue = {}},
             };
@@ -279,7 +327,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
 
             // Check condition
             const res: bool = switch (try evalExpr(stmt.cond, env)) {
-                .Int => return TypeError.MismatchedType,
+                .Int, .Callable, .Void => return TypeError.MismatchedType,
                 .Bool => |b| b,
             };
 
@@ -302,7 +350,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
 
                 // Check condition
                 const res: bool = switch (try evalExpr(stmt.cond, env)) {
-                    .Int => return TypeError.MismatchedType,
+                    .Int, .Callable, .Void => return TypeError.MismatchedType,
                     .Bool => |b| b,
                 };
 
@@ -315,6 +363,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
                 // Evaluate body and consume break statements
                 switch(try evalStmt(stmt.body, &scoped)) {
                     .NoReturn => {},
+                    .Return => |lit| return StmtReturn {.Return = lit},
                     .Break => break,
                     .Continue => continue,
                 }
@@ -324,6 +373,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
         },
         .BreakStmt => return StmtReturn {.Break = {}},
         .ContinueStmt => return StmtReturn {.Continue = {}},
+        .ReturnStmt => |expr| return StmtReturn {.Return = try evalExpr(expr, env)},
     }
 
     unreachable;
@@ -334,6 +384,7 @@ pub fn evalProc(procedure: ast.Proc, env: *venv.Env) EvalError!void {
     // Evaluate statements one by one
     for (procedure.stmts) |stmt| switch (try evalStmt(stmt, env)) {
         .NoReturn => {},
+        .Return => return EvalError.UnexpectedReturn,
         .Break => return EvalError.UnexpectedBreak,
         .Continue => return EvalError.UnexpectedContinue,
     };

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -374,6 +374,21 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
         .BreakStmt => return StmtReturn {.Break = {}},
         .ContinueStmt => return StmtReturn {.Continue = {}},
         .ReturnStmt => |expr| return StmtReturn {.Return = try evalExpr(expr, env)},
+        .FunDefStmt => |stmt| {
+
+            // Insert function into environment
+            if (env.isDeclaredLocal(stmt.id)) return EvalError.IdentifierAlreadyDeclared;
+            env.insert(
+                stmt.id,
+                venv.ObjectVal {.Var = ast.Lit {.Callable = ast.Callable {
+                    .params = stmt.params,
+                    .body = stmt.body,
+                    .closure = env
+                }}}
+            );
+
+            return StmtReturn {.NoReturn = {}};
+        },
     }
 
     unreachable;

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -226,6 +226,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
                 };
 
                 // Evalute left-hand side lval to an identifier
+                // TODO: This can also be array indexing, object field/property, etc.
                 const id: []const u8 = switch (try lhs) {
                     .Var => |id| id
                 };
@@ -237,6 +238,10 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
                 env.insert(id, venv.ObjectVal {.Undefined = {}});
 
                 // Evaluate assignment expression if exists
+                // TODO: Try to manually evaluate the assignment expression to fix
+                // declare x = 10
+                // { declare x = x + 1 }
+                // bug
                 switch (expr.*) {
                     .AssignExpr => |*exp| _ = try evalAssignExpr(exp, env),
                     .Lval => {},

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -42,8 +42,8 @@ pub fn evalLval(lval: ast.Lval, env: *venv.Env) ValueError!ast.Lit {
                 .Var => |val| switch (val) {
                     .Int => |ival| ast.Lit {.Int = ival},
                     .Bool => |bval| ast.Lit {.Bool = bval},
-                    .Undefined => EvalError.UndefinedVariable,
-                }
+                },
+                .Undefined => EvalError.UndefinedVariable
             };
 
         }
@@ -179,7 +179,7 @@ pub fn evalAssignExpr(expr: *const ast.AssignExpr, env: *venv.Env) EvalError!ast
     switch (lval) {
         .Var => |id| {
             if (!env.isDeclaredGlobal(id)) return EvalError.UndefinedVariable;
-            env.insertScoping(id, venv.ObjectVal {.Var = venv.Value.fromLiteral(rhs)});
+            env.insertScoping(id, venv.ObjectVal {.Var = rhs});
         }
     }
 
@@ -234,7 +234,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
                 if (env.isDeclaredLocal(id)) return EvalError.IdentifierAlreadyDeclared;
 
                 // Add lhs identifier to environment
-                env.insert(id, venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
+                env.insert(id, venv.ObjectVal {.Undefined = {}});
 
                 // Evaluate assignment expression if exists
                 switch (expr.*) {

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -57,7 +57,7 @@ fn operator_from_string(str: []const u8) token.Token {
 }
 
 fn is_keyword(chars: []const u8) bool {
-    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue"}, chars);
+    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function"}, chars);
 }
 
 fn keyword_from_string(str: []const u8) token.Token {
@@ -68,6 +68,8 @@ fn keyword_from_string(str: []const u8) token.Token {
     if (std.mem.eql(u8, str, "while")) return token.Token {.WHILE = {}};
     if (std.mem.eql(u8, str, "break")) return token.Token {.BREAK = {}};
     if (std.mem.eql(u8, str, "continue")) return token.Token {.CONTINUE = {}};
+    if (std.mem.eql(u8, str, "return")) return token.Token {.RETURN = {}};
+    if (std.mem.eql(u8, str, "function")) return token.Token {.FUN = {}};
     unreachable;
 }
 
@@ -284,7 +286,7 @@ pub const Lexer = struct {
 
                 // Allow line breaks before statement keywords
                 // NOTE: Including single-word statements here to get LB error on "break x"
-                .DECLARE, .PRINT, .IF, .ELSE, .WHILE, .BREAK, .CONTINUE => {
+                .DECLARE, .PRINT, .IF, .ELSE, .WHILE, .BREAK, .CONTINUE, .RETURN, .FUN => {
                     self.pushLB(&res);
                     res.append(tok) catch unreachable;
                     isStatement = true;

--- a/src/tests/env.zig
+++ b/src/tests/env.zig
@@ -1,4 +1,5 @@
 const venv = @import("../env.zig");
+const ast = @import("../ast.zig");
 
 const std = @import("std");
 
@@ -9,13 +10,13 @@ test "insert and lookup" {
     defer env.deinit();
 
     // Place value
-    env.insert("x", venv.ObjectVal {.Var = venv.Value {.Int = 32}});
+    env.insert("x", venv.ObjectVal {.Var = ast.Lit {.Int = 32}});
 
     // Lookup
     const v: ?venv.ObjectVal = env.lookup("x");
     try std.testing.expectEqualDeep(
         v,
-        venv.ObjectVal {.Var = venv.Value {.Int = 32}}
+        venv.ObjectVal { .Var = ast.Lit {.Int = 32}}
     );
 }
 
@@ -29,13 +30,13 @@ test "insert and lookup 2" {
     const identifier: []const u8 = "x";
 
     // Place value
-    env.insert(identifier, venv.ObjectVal {.Var = venv.Value {.Int = 32}});
+    env.insert(identifier, venv.ObjectVal { .Var = ast.Lit {.Int = 32}});
 
     // Lookup
     const v: ?venv.ObjectVal = env.lookup("x");
     try std.testing.expectEqualDeep(
         v,
-        venv.ObjectVal {.Var = venv.Value {.Int = 32}}
+        venv.ObjectVal { .Var = ast.Lit {.Int = 32}}
     );
 }
 
@@ -48,13 +49,13 @@ test "insert and lookup 3" {
     const identifier: []const u8 = "x";
 
     // Place value
-    env.insert(identifier, venv.ObjectVal {.Var = venv.Value {.Int = 32}});
+    env.insert(identifier, venv.ObjectVal { .Var = ast.Lit {.Int = 32}});
 
     // Lookup
     const v: ?venv.ObjectVal = env.lookup(identifier);
     try std.testing.expectEqualDeep(
         v,
-        venv.ObjectVal {.Var = venv.Value {.Int = 32}}
+        venv.ObjectVal { .Var = ast.Lit {.Int = 32}}
     );
 }
 
@@ -69,12 +70,12 @@ test "insert and lookup 4" {
     const identifier2: []const u8 = "x";
 
     // Place value
-    env.insert(identifier, venv.ObjectVal {.Var = venv.Value {.Int = 32}});
+    env.insert(identifier, venv.ObjectVal { .Var = ast.Lit {.Int = 32}});
 
     // Lookup
     const v: ?venv.ObjectVal = env.lookup(identifier2);
     try std.testing.expectEqualDeep(
         v,
-        venv.ObjectVal {.Var = venv.Value {.Int = 32}}
+        venv.ObjectVal { .Var = ast.Lit {.Int = 32}}
     );
 }

--- a/src/tests/interpreter.zig
+++ b/src/tests/interpreter.zig
@@ -749,9 +749,9 @@ test "undefined variable in comma declaration" {
 }
 
 test "simple funcall" {
-    // Prepare environment
+    // Prepare environment NOTE: we only deinit the table not the environment here..
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("always1", venv.ObjectVal {.Var = ast.Lit {
@@ -780,7 +780,7 @@ test "simple funcall" {
 test "simple funcall one param" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("double", venv.ObjectVal {.Var = ast.Lit {
@@ -815,7 +815,7 @@ test "simple funcall one param" {
 test "simple funcall three params" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("sum", venv.ObjectVal {.Var = ast.Lit {
@@ -856,7 +856,7 @@ test "simple funcall three params" {
 test "simple funcall no return" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("voidfun", venv.ObjectVal {.Var = ast.Lit {
@@ -886,7 +886,7 @@ test "simple funcall no return" {
 test "function closure works" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert some variable x
     env.insert("x", venv.ObjectVal {.Var = ast.Lit {.Int = 19}});
@@ -925,7 +925,7 @@ test "function closure works" {
 test "function closure works 2" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert some variable x
     env.insert("x", venv.ObjectVal {.Var = ast.Lit {.Int = 19}});
@@ -964,7 +964,7 @@ test "function closure works 2" {
 test "function argument shadow closure scope" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert some variable x
     env.insert("x", venv.ObjectVal {.Var = ast.Lit {.Int = 19}});
@@ -1004,7 +1004,7 @@ test "function argument shadow closure scope" {
 test "re-declaring outer variable in function local scope" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert some variable x
     env.insert("x", venv.ObjectVal {.Var = ast.Lit {.Int = 19}});
@@ -1045,7 +1045,7 @@ test "re-declaring outer variable in function local scope" {
 test "wrong argument count 1" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("dummyfun", venv.ObjectVal {.Var = ast.Lit {
@@ -1074,7 +1074,7 @@ test "wrong argument count 1" {
 test "wrong argument count 2" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("dummyfun", venv.ObjectVal {.Var = ast.Lit {
@@ -1104,7 +1104,7 @@ test "wrong argument count 2" {
 test "recursion 1" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("fac", venv.ObjectVal {.Var = ast.Lit {
@@ -1160,7 +1160,7 @@ test "recursion 1" {
 test "recursion 2" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert function into environment
     env.insert("fac", venv.ObjectVal {.Var = ast.Lit {
@@ -1215,7 +1215,7 @@ test "recursion 2" {
 test "mutual recursion" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    defer env.deinit();
+    defer env.table.deinit();
 
     // Insert functions into environment
     env.insert("even", venv.ObjectVal {.Var = ast.Lit {

--- a/src/tests/interpreter.zig
+++ b/src/tests/interpreter.zig
@@ -78,7 +78,7 @@ test "variable lookup" {
     const identifier: []const u8 = "x";
     var env = venv.Env.new(std.testing.allocator);
     defer env.deinit();
-    env.insert(identifier, venv.ObjectVal {.Var = venv.Value {.Int = 32}});
+    env.insert(identifier, venv.ObjectVal { .Var = ast.Lit {.Int = 32}});
 
     const exp: ast.Expr = ast.Expr {
         .Lval = ast.Lval {.Var = identifier}
@@ -94,7 +94,7 @@ test "variable assignment" {
 
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    env.insert("x", venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
+    env.insert("x", venv.ObjectVal { .Undefined = {}});
     defer env.deinit();
 
     const exp: ast.Expr = ast.Expr {
@@ -126,7 +126,7 @@ test "let x (= undefined)" {
 
     // Assert that environment has been updated with x = 49
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Undefined = {}}},
+        venv.ObjectVal { .Undefined = {}},
         env.lookup("x")
     );
 }
@@ -149,7 +149,7 @@ test "let x = 49" {
 
     // Assert that environment has been updated with x = 49
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 49}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 49}},
         env.lookup("x")
     );
 }
@@ -179,7 +179,7 @@ test "invalid chain declaration" {
 test "redeclaration error" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    env.insert("x", venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
+    env.insert("x", venv.ObjectVal { .Undefined = {}});
     defer env.deinit();
 
     // Prepare statement
@@ -197,7 +197,7 @@ test "redeclaration error" {
 test "redeclaration error 2" {
     // Prepare environment
     var env = venv.Env.new(std.testing.allocator);
-    env.insert("x", venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
+    env.insert("x", venv.ObjectVal { .Undefined = {}});
     defer env.deinit();
 
     // Prepare statement
@@ -245,7 +245,7 @@ test "smart scoped assignment" {
     // Evaluate statement to error for z
     try interpreter.evalProc(proc, &env);
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 20}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 20}},
         env.lookup("x")
     );
 }
@@ -288,7 +288,7 @@ test "smart scoped declaration" {
     // Evaluate statement to error for z
     try interpreter.evalProc(proc, &env);
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 10}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 10}},
         env.lookup("x")
     );
 }
@@ -434,7 +434,7 @@ test "break works" {
     // Evaluate statement to error for z
     try interpreter.evalProc(proc, &env);
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 9}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 9}},
         env.lookup("x")
     );
 }
@@ -487,7 +487,7 @@ test "break in block works" {
     // Evaluate statement to error for z
     try interpreter.evalProc(proc, &env);
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 9}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 9}},
         env.lookup("x")
     );
 }
@@ -540,7 +540,7 @@ test "continue works" {
     // Evaluate statement to error for z
     try interpreter.evalProc(proc, &env);
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 0}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 0}},
         env.lookup("y")
     );
 }
@@ -597,7 +597,7 @@ test "continue in block works" {
     // Evaluate statement to error for z
     try interpreter.evalProc(proc, &env);
     try std.testing.expectEqualDeep(
-        venv.ObjectVal {.Var = venv.Value {.Int = 0}},
+        venv.ObjectVal { .Var = ast.Lit {.Int = 0}},
         env.lookup("y")
     );
 }
@@ -709,10 +709,10 @@ test "comma declaration" {
 
     // Evaluate procedure
     _ = try interpreter.evalProc(proc, &env);
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 1}}, env.lookup("x"));
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 2}}, env.lookup("y"));
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Undefined = {}}}, env.lookup("z"));
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 1}}, env.lookup("w"));
+    try std.testing.expectEqualDeep(venv.ObjectVal { .Var = ast.Lit {.Int = 1}}, env.lookup("x"));
+    try std.testing.expectEqualDeep(venv.ObjectVal { .Var = ast.Lit {.Int = 2}}, env.lookup("y"));
+    try std.testing.expectEqualDeep(venv.ObjectVal { .Undefined = {}}, env.lookup("z"));
+    try std.testing.expectEqualDeep(venv.ObjectVal { .Var = ast.Lit {.Int = 1}}, env.lookup("w"));
 }
 
 test "undefined variable in comma declaration" {

--- a/src/tests/lexer.zig
+++ b/src/tests/lexer.zig
@@ -1478,3 +1478,38 @@ test "comma declaration" {
 
     try std.testing.expectEqualDeep(expected, tokens.items);
 }
+
+test "inline simple function definition with return" {
+    const input =
+        \\declare x = 0
+        \\function last(x, y, z) return z
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.DECLARE = {}},
+        Token {.IDENT = "x"},
+        Token {.EQ = {}},
+        Token {.INTLIT = 0},
+        Token {.LB = {}},
+        Token {.FUN = {}},
+        Token {.IDENT = "last"},
+        Token {.LPAREN = {}},
+        Token {.IDENT = "x"},
+        Token {.COMMA = {}},
+        Token {.IDENT = "y"},
+        Token {.COMMA = {}},
+        Token {.IDENT = "z"},
+        Token {.RPAREN = {}},
+        Token {.LB = {}},
+        Token {.RETURN = {}},
+        Token {.IDENT = "z"},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}

--- a/src/tests/parser.zig
+++ b/src/tests/parser.zig
@@ -1751,3 +1751,125 @@ test "return statement with expression at the end" {
     try std.testing.expectEqualDeep(expect, actual);
 
 }
+
+test "simple inline function definition" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.FUN = {}});
+    try tokens.append(Token {.IDENT = "last"});
+    try tokens.append(Token {.LPAREN = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "y"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "z"});
+    try tokens.append(Token {.RPAREN = {}});
+    try tokens.append(Token {.LB = {}});
+    try tokens.append(Token {.RETURN = {}});
+    try tokens.append(Token {.IDENT = "z"});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const expect: ast.Stmt = ast.Stmt {.FunDefStmt = &ast.FunDefStmt {
+        .id = "last",
+        .params = &[_]ast.Var {"x", "y", "z"},
+        .body = ast.Stmt {.ReturnStmt = &ast.Expr {.Lval = ast.Lval {.Var = "z"}}}
+    }};
+
+    const actual: ast.Stmt = try prs.parseStmt();
+    defer actual.destroyAll(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(expect, actual);
+}
+
+
+
+// test "function definition with trailing comma" {
+
+//     var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+//     try tokens.append(Token {.FUN = {}});
+//     try tokens.append(Token {.IDENT = "last"});
+//     try tokens.append(Token {.LPAREN = {}});
+//     try tokens.append(Token {.IDENT = "x"});
+//     try tokens.append(Token {.COMMA = {}});
+//     try tokens.append(Token {.IDENT = "y"});
+//     try tokens.append(Token {.COMMA = {}});
+//     try tokens.append(Token {.RPAREN = {}});
+//     try tokens.append(Token {.LB = {}});
+//     try tokens.append(Token {.RETURN = {}});
+//     try tokens.append(Token {.IDENT = "z"});
+//     try tokens.append(Token {.EOF = {}});
+//     defer tokens.deinit();
+
+//     var prs: parser.Parser = .new(tokens, std.testing.allocator);
+//     const res: parser.ParseError!ast.Stmt = prs.parseStmt();
+
+//     try std.testing.expectEqualDeep(parser.ParseError.ExpectedIdentifier, res);
+// }
+
+
+test "function definition no name" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.FUN = {}});
+    try tokens.append(Token {.LPAREN = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "y"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.RPAREN = {}});
+    try tokens.append(Token {.LB = {}});
+    try tokens.append(Token {.RETURN = {}});
+    try tokens.append(Token {.IDENT = "z"});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+    const res: parser.ParseError!ast.Stmt = prs.parseStmt();
+
+    try std.testing.expectEqualDeep(parser.ParseError.ExpectedIdentifier, res);
+}
+
+
+test "function definition no body" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.FUN = {}});
+    try tokens.append(Token {.IDENT = "afun"});
+    try tokens.append(Token {.LPAREN = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "y"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.RPAREN = {}});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+    const res: parser.ParseError!ast.Stmt = prs.parseStmt();
+
+    try std.testing.expectEqualDeep(parser.ParseError.ExpectedLineBreak, res);
+}
+
+test "function definition no body 2" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.FUN = {}});
+    try tokens.append(Token {.IDENT = "afun"});
+    try tokens.append(Token {.LPAREN = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.IDENT = "y"});
+    try tokens.append(Token {.COMMA = {}});
+    try tokens.append(Token {.RPAREN = {}});
+    try tokens.append(Token {.LB = {}});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+    const res: parser.ParseError!ast.Stmt = prs.parseStmt();
+
+    try std.testing.expectEqualDeep(parser.ParseError.ExpectedStatement, res);
+}

--- a/src/tests/parser.zig
+++ b/src/tests/parser.zig
@@ -1658,3 +1658,96 @@ test "funcall funcall funcall" {
 
     try std.testing.expectEqualDeep(expect, result.*);
 }
+
+test "empty return statement" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.RETURN = {}});
+    try tokens.append(Token {.LB = {}});
+    try tokens.append(Token {.DECLARE = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const expect: ast.Stmt = ast.Stmt {.ReturnStmt = &ast.Expr {.Lit = ast.Lit {.Void = {}}}};
+
+    const actual: ast.Stmt = try prs.parseStmt();
+    defer actual.destroyAll(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(expect, actual);
+
+}
+
+test "return statement with expression" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.RETURN = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.PLUS = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.LB = {}});
+    try tokens.append(Token {.DECLARE = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const expect: ast.Stmt = ast.Stmt {.ReturnStmt = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
+        .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+        .op = .Add,
+        .rhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+    }}};
+
+    const actual: ast.Stmt = try prs.parseStmt();
+    defer actual.destroyAll(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(expect, actual);
+
+}
+
+
+test "empty return statement at the end" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.RETURN = {}});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const expect: ast.Stmt = ast.Stmt {.ReturnStmt = &ast.Expr {.Lit = ast.Lit {.Void = {}}}};
+
+    const actual: ast.Stmt = try prs.parseStmt();
+    defer actual.destroyAll(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(expect, actual);
+
+}
+
+test "return statement with expression at the end" {
+
+    var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
+    try tokens.append(Token {.RETURN = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.PLUS = {}});
+    try tokens.append(Token {.IDENT = "x"});
+    try tokens.append(Token {.EOF = {}});
+    defer tokens.deinit();
+
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const expect: ast.Stmt = ast.Stmt {.ReturnStmt = &ast.Expr {.BinOpExpr = ast.BinOpExpr {
+        .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+        .op = .Add,
+        .rhs = &ast.Expr {.Lval = ast.Lval {.Var = "x"}},
+    }}};
+
+    const actual: ast.Stmt = try prs.parseStmt();
+    defer actual.destroyAll(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(expect, actual);
+
+}

--- a/src/tests/repl.zig
+++ b/src/tests/repl.zig
@@ -75,7 +75,7 @@ test "variable eval with premade environment" {
 
     var env = venv.Env.new(std.testing.allocator);
     defer env.deinit();
-    env.insert("some_variable", venv.ObjectVal {.Var = venv.Value {.Int = 2193}});
+    env.insert("some_variable", venv.ObjectVal {.Var = ast.Lit {.Int = 2193}});
 
     const res: ast.Lit = try interpreter.evalExpr(expr, &env);
 
@@ -95,7 +95,7 @@ test "assignment expression" {
     defer expr.destroyAll(std.testing.allocator);
 
     var env = venv.Env.new(std.testing.allocator);
-    env.insert("variable", venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
+    env.insert("variable", venv.ObjectVal {.Undefined = {}});
     defer env.deinit();
 
     const res: ast.Lit = try interpreter.evalExpr(expr, &env);
@@ -116,8 +116,8 @@ test "double assignment" {
     defer expr.destroyAll(std.testing.allocator);
 
     var env = venv.Env.new(std.testing.allocator);
-    env.insert("x", venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
-    env.insert("y", venv.ObjectVal {.Var = venv.Value {.Undefined = {}}});
+    env.insert("x", venv.ObjectVal {.Undefined = {}});
+    env.insert("y", venv.ObjectVal {.Undefined = {}});
     defer env.deinit();
 
     const res: ast.Lit = try interpreter.evalExpr(expr, &env);
@@ -144,7 +144,7 @@ test "declare statement undefined" {
 
     // Assert that x has been added into environment as undefined
     const objval: ?venv.ObjectVal = env.lookup("x");
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Undefined = {}}}, objval);
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Undefined = {}}, objval);
 }
 
 
@@ -172,7 +172,7 @@ test "break statement" {
 
     // Assert that x has been added into environment as undefined
     const objval: ?venv.ObjectVal = env.lookup("x");
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 5}}, objval);
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = ast.Lit {.Int = 5}}, objval);
 }
 
 test "continue statement" {
@@ -202,5 +202,5 @@ test "continue statement" {
 
     // Assert that x has been added into environment as undefined
     const objval: ?venv.ObjectVal = env.lookup("y");
-    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = venv.Value {.Int = 1}}, objval);
+    try std.testing.expectEqualDeep(venv.ObjectVal {.Var = ast.Lit {.Int = 1}}, objval);
 }

--- a/src/token.zig
+++ b/src/token.zig
@@ -30,6 +30,7 @@ pub const TokenType: type = enum {
     WHILE,
     BREAK,
     CONTINUE,
+    FUN,
     LB,
     COMMA,
     EOF,
@@ -76,6 +77,7 @@ pub const Token: type = union(TokenType) {
     WHILE: void,
     BREAK: void,
     CONTINUE: void,
+    FUN: void,
 
     // Utility
     LB: void,
@@ -124,6 +126,7 @@ pub const Token: type = union(TokenType) {
             .WHILE    => try writer.print("[WHILE   ]:", .{}),
             .BREAK    => try writer.print("[BREAK   ]:", .{}),
             .CONTINUE => try writer.print("[CONTINUE]:", .{}),
+            .FUN      => try writer.print("[FUN     ]:", .{}),
             .INTLIT   => |val| try writer.print("[INTLIT  ]: {}", .{val}),
             .BOOLLIT  => |val| try writer.print("[BOOLLIT ]: {}", .{val}),
             .IDENT    => |val| try writer.print("[IDENT   ]: {s}", .{val})
@@ -133,6 +136,7 @@ pub const Token: type = union(TokenType) {
     pub fn getInfixPrecedence(self: Token) ?InfixPrecedence {
         // TODO:
         // Implement the remaining tokens here..
+        // TODO: FUN should be binding hard here...
         return switch(self) {
 
             // Right-associative assignment
@@ -156,6 +160,14 @@ pub const Token: type = union(TokenType) {
     pub fn getPrefixPrecedence(self: Token) ?u8 {
         return switch(self) {
             .MINUS, .NOT => 13,
+            else => null
+        };
+    }
+
+    pub fn getPostfixPrecedence(self: Token) ?u8 {
+        return switch(self) {
+            // TODO: Implement arr[idx] and object.field operators
+            .LPAREN => 15,
             else => null
         };
     }

--- a/src/token.zig
+++ b/src/token.zig
@@ -30,6 +30,7 @@ pub const TokenType: type = enum {
     WHILE,
     BREAK,
     CONTINUE,
+    RETURN,
     FUN,
     LB,
     COMMA,
@@ -77,6 +78,7 @@ pub const Token: type = union(TokenType) {
     WHILE: void,
     BREAK: void,
     CONTINUE: void,
+    RETURN: void,
     FUN: void,
 
     // Utility
@@ -126,6 +128,7 @@ pub const Token: type = union(TokenType) {
             .WHILE    => try writer.print("[WHILE   ]:", .{}),
             .BREAK    => try writer.print("[BREAK   ]:", .{}),
             .CONTINUE => try writer.print("[CONTINUE]:", .{}),
+            .RETURN   => try writer.print("[RETURN  ]:", .{}),
             .FUN      => try writer.print("[FUN     ]:", .{}),
             .INTLIT   => |val| try writer.print("[INTLIT  ]: {}", .{val}),
             .BOOLLIT  => |val| try writer.print("[BOOLLIT ]: {}", .{val}),


### PR DESCRIPTION
Performed the following changes:
- Refactored environment to hold ast literals instead of own type
- Removed some dead code
- Added function call expressions
- Added Callable as new literal
- Added return statements
- Added Void as new literal
- Added function  definitions

It should now be possible to have cool stuff like functions as first-class values and mutual recursion.
Syntax for function definitions is the following:
```
function one() return 1
function two()
    return 2
function three() { return 3 }
function four() {
    return 4
}
function five()
{
    return 5
}

function ifstmt(cond, a, b) if cond return a else return b
function ifstmt2(cond, a, b)
    if cond
        return a
    else
        return b
```