### PR TITLE
17 add listsarrays

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,6 +69,34 @@ gives output
 #+begin_example
 89
 #+end_example
+** Lists
+#+begin_src
+function copy(dst, src) {
+    declare idx = 0
+    while idx < src.size {
+        dst[idx] = src[idx]
+        idx = idx + 1
+    }
+}
+
+function append(list, item) {
+    declare tmp[list.size + 1]
+    copy(tmp, list)
+    tmp[list.size] = item
+    return tmp
+}
+
+declare mylist[4] = 0
+print mylist
+
+mylist = append(mylist, 1)
+print mylist
+#+end_src
+gives output
+#+begin_example
+[0,0,0,0,]
+[0,0,0,0,1,]
+#+end_example
 
 * Features
 ** Implemented
@@ -80,11 +108,11 @@ gives output
 - COMMA declarations, e.g. ~declare x = 1, y = 2, z = 3~
 - Function definitions and function calls
 - Higher-order functions (passing functions as parameters)
+- Lists with dynamic types
 
 ** Not yet implemented
 - String types
 - Floating point types
-- Lists
 - Structs
 - For-loops
 - INPUT statements

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -127,20 +127,41 @@ pub const ListIndex: type = struct {
     ) !void {
         _ = fmt;
         _ = options;
-        try writer.print("{s}[{}]", .{self.id, self.idx});
+        try writer.print("{}[{}]", .{self.id, self.idx});
+    }
+};
+
+pub const PropertyAccess: type = struct {
+    lhs: *const Expr,
+    prop: *const Expr,
+
+    pub fn destroyAll(self: *const PropertyAccess, allocator: std.mem.Allocator) void {
+        self.lhs.destroyAll(allocator);
+        self.prop.destroyAll(allocator);
+    }
+
+    pub fn format(
+        self: PropertyAccess,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype
+    ) !void {
+        _ = fmt;
+        _ = options;
+        try writer.print("{}.{}", .{self.lhs, self.prop});
     }
 };
 
 pub const Lval = union(enum) {
     Var: Var,
     ListIndex: ListIndex,
-
-    // TODO: Add field lookup
+    PropertyAccess: PropertyAccess,
 
     pub fn destroyAll(self: *const Lval, allocator: std.mem.Allocator) void {
         switch (self.*) {
             .Var => {},
             .ListIndex => |l| l.destroyAll(allocator),
+            .PropertyAccess => |p| p.destroyAll(allocator),
         }
     }
 
@@ -154,7 +175,8 @@ pub const Lval = union(enum) {
         _ = options;
         switch(self) {
             .Var => |v| try writer.print("{s}", .{v}),
-            .ListIndex => |l| try writer.print("{s}", .{l})
+            .ListIndex => |l| try writer.print("{}", .{l}),
+            .PropertyAccess => |p| try writer.print("{}", .{p})
         }
     }
 };

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -462,7 +462,6 @@ pub const Stmt = union(enum) {
     ContinueStmt: void,
     ReturnStmt: *const Expr,
     FunDefStmt: *const FunDefStmt,
-    MakeStmt: []const *const Expr,
 
     pub fn destroyAll(self: *const Stmt, allocator: std.mem.Allocator) void {
         switch (self.*) {
@@ -485,10 +484,6 @@ pub const Stmt = union(enum) {
             .ContinueStmt => {},
             .ReturnStmt => |expr| expr.destroyAll(allocator),
             .FunDefStmt => |stmt| stmt.destroyAll(allocator),
-            .MakeStmt => |exprs| {
-                for (exprs) |expr| expr.destroyAll(allocator);
-                allocator.free(exprs);
-            },
         }
     }
 
@@ -523,11 +518,6 @@ pub const Stmt = union(enum) {
             .ContinueStmt => try writer.print("CONTINUE\n", .{}),
             .ReturnStmt => |expr| try writer.print("RETURN {}\n", .{expr}),
             .FunDefStmt => |stmt| try writer.print("{}", .{stmt}),
-            .MakeStmt => |exprs| {
-                try writer.print("MAKE ", .{});
-                for (exprs) |expr| try writer.print("{}, ", .{expr});
-                try writer.print("\n", .{});
-            },
         };
     }
 };

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -8,11 +8,13 @@ pub const Callable = struct {
     closure: *venv.Env,
 
     pub fn destroyAll(self: *const Callable, allocator: std.mem.Allocator) void {
+
         _ = self;
         _ = allocator;
 
         // BUG: This *shoud* result in memory leaks
         // but so far testing haven't caught it..
+        // This will be destroyed when the corresponding FunDeclStatement is destroyed
 
         // allocator.free(self.params);
         // self.body.destroyAll(allocator);
@@ -29,7 +31,46 @@ pub const Callable = struct {
         _ = options;
         try writer.print("(", .{});
         for (self.params) |param| try writer.print("{s},", .{param});
-        try writer.print(") => {}\n", .{self.body});
+        try writer.print(") => {}", .{self.body});
+    }
+
+};
+
+pub const List = struct {
+
+    len: usize,
+    items: []Lit,
+
+    refs: u32 = 1,
+
+    pub fn makeReference(self: *List) *List {
+
+        self.refs = self.refs + 1;
+        return self;
+    }
+
+    pub fn destroyAll(self: *List, allocator: std.mem.Allocator) void {
+
+        // Use reference-counting
+        self.refs = self.refs - 1;
+        if (self.refs <= 0) {
+            for (self.items) |*item| item.destroyAll(allocator);
+            allocator.free(self.items);
+            allocator.destroy(self);
+        }
+    }
+
+    pub fn format(
+        self: List,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype
+    ) !void {
+        _ = fmt;
+        _ = options;
+        try writer.print("[", .{});
+        for (self.items) |item| try writer.print("{s},", .{item});
+        try writer.print("]", .{});
     }
 
 };
@@ -39,11 +80,13 @@ pub const Lit = union(enum) {
     Bool: bool,
     Void: void,
     Callable: Callable,
+    List: *List,
 
-    pub fn destroyAll(self: *const Lit, allocator: std.mem.Allocator) void {
+    pub fn destroyAll(self: *Lit, allocator: std.mem.Allocator) void {
         switch (self.*) {
             .Int, .Bool, .Void => {},
-            .Callable => |fun| fun.destroyAll(allocator)
+            .Callable => |fun| fun.destroyAll(allocator),
+            .List => |lst| lst.destroyAll(allocator),
         }
     }
 
@@ -60,17 +103,46 @@ pub const Lit = union(enum) {
             .Bool => |v| try writer.print("{}", .{v}),
             .Void => try writer.print("{{}}", .{}),
             .Callable => |f| try writer.print("{}", .{f}),
+            .List => |l| try writer.print("{}", .{l}),
         }
     }
 };
 
 pub const Var: type = []const u8;
 
+pub const ListIndex: type = struct {
+    id: *const Expr,
+    idx: *const Expr,
+
+    pub fn destroyAll(self: *const ListIndex, allocator: std.mem.Allocator) void {
+        self.id.destroyAll(allocator);
+        self.idx.destroyAll(allocator);
+    }
+
+    pub fn format(
+        self: ListIndex,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype
+    ) !void {
+        _ = fmt;
+        _ = options;
+        try writer.print("{s}[{}]", .{self.id, self.idx});
+    }
+};
+
 pub const Lval = union(enum) {
     Var: Var,
+    ListIndex: ListIndex,
 
-    // TODO: Add array index and field lookup
+    // TODO: Add field lookup
 
+    pub fn destroyAll(self: *const Lval, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .Var => {},
+            .ListIndex => |l| l.destroyAll(allocator),
+        }
+    }
 
     pub fn format(
         self: Lval,
@@ -81,7 +153,8 @@ pub const Lval = union(enum) {
         _ = fmt;
         _ = options;
         switch(self) {
-            .Var => |v| try writer.print("{s}", .{v})
+            .Var => |v| try writer.print("{s}", .{v}),
+            .ListIndex => |l| try writer.print("{s}", .{l})
         }
     }
 };
@@ -278,7 +351,7 @@ pub const Expr = union(enum) {
             .BinOpExpr => |*expr| expr.destroyAll(allocator),
             .UnOpExpr => |*expr| expr.destroyAll(allocator),
             .Lit => {},
-            .Lval => {}, // TODO: Figure out if this needs implementation
+            .Lval => |*lval| lval.destroyAll(allocator),
             .AssignExpr => |*expr| expr.destroyAll(allocator),
             .CallExpr => |*expr| expr.destroyAll(allocator),
         }
@@ -389,6 +462,7 @@ pub const Stmt = union(enum) {
     ContinueStmt: void,
     ReturnStmt: *const Expr,
     FunDefStmt: *const FunDefStmt,
+    MakeStmt: []const *const Expr,
 
     pub fn destroyAll(self: *const Stmt, allocator: std.mem.Allocator) void {
         switch (self.*) {
@@ -411,6 +485,10 @@ pub const Stmt = union(enum) {
             .ContinueStmt => {},
             .ReturnStmt => |expr| expr.destroyAll(allocator),
             .FunDefStmt => |stmt| stmt.destroyAll(allocator),
+            .MakeStmt => |exprs| {
+                for (exprs) |expr| expr.destroyAll(allocator);
+                allocator.free(exprs);
+            },
         }
     }
 
@@ -445,6 +523,11 @@ pub const Stmt = union(enum) {
             .ContinueStmt => try writer.print("CONTINUE\n", .{}),
             .ReturnStmt => |expr| try writer.print("RETURN {}\n", .{expr}),
             .FunDefStmt => |stmt| try writer.print("{}", .{stmt}),
+            .MakeStmt => |exprs| {
+                try writer.print("MAKE ", .{});
+                for (exprs) |expr| try writer.print("{}, ", .{expr});
+                try writer.print("\n", .{});
+            },
         };
     }
 };

--- a/src/env.zig
+++ b/src/env.zig
@@ -36,7 +36,7 @@ pub const Env: type = struct {
         // This is necessary, as some could be Callables with their own statements
         var iterator = self.table.valueIterator();
         while (iterator.next()) |val_ptr| switch (val_ptr.*) {
-            .Var => |lit| lit.destroyAll(self.allocator),
+            .Var => |*lit| lit.destroyAll(self.allocator),
             .Undefined => {},
         };
 

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -14,6 +14,8 @@ const ArithmeticError = error {
 const ValueError = error {
     UndefinedVariable,
     UnexpectedVoidValue,
+    IndexOutOfBounds,
+    InvalidSize,
 };
 const SemanticError = error {
     IdentifierAlreadyDeclared,
@@ -23,6 +25,8 @@ const SemanticError = error {
     NotCallable,
     WrongArgCount,
     InvalidUpcall,
+    NotList,
+    ListReference,
 };
 
 pub const EvalError = TypeError || ArithmeticError || ValueError || SemanticError;
@@ -35,7 +39,7 @@ pub const StmtReturn: type = union(enum) {
 };
 
 // Functions
-pub fn evalLval(lval: ast.Lval, env: *venv.Env) ValueError!ast.Lit {
+pub fn evalLval(lval: ast.Lval, env: *venv.Env) EvalError!ast.Lit {
     return switch (lval) {
         .Var => |v| {
 
@@ -50,11 +54,32 @@ pub fn evalLval(lval: ast.Lval, env: *venv.Env) ValueError!ast.Lit {
                     .Int => |ival| ast.Lit {.Int = ival},
                     .Bool => |bval| ast.Lit {.Bool = bval},
                     .Void => ValueError.UnexpectedVoidValue,
-                    .Callable => |fun| ast.Lit {.Callable = fun}
+                    .Callable => |fun| ast.Lit {.Callable = fun},
+                    .List => |lst| ast.Lit {.List = lst},
                 },
                 .Undefined => EvalError.UndefinedVariable
             };
 
+        },
+        .ListIndex => |l| {
+
+            // Evaluate identifier (should lookup in environment..)
+            const list: ast.List = switch (try evalExpr(l.id, env)) {
+                .List => |lst| lst.*,
+                .Int, .Bool, .Void, .Callable => return EvalError.NotList
+            };
+
+            // Evaluate index
+            const index: i64 = switch (try evalExpr(l.idx, env)) {
+                .Int => |i| i,
+                .Bool, .Void, .Callable, .List => return EvalError.MismatchedType
+            };
+
+            // Make sure index is within bounds
+            if (index < 0 or index >= list.len) return EvalError.IndexOutOfBounds;
+
+            // Lookup by index
+            return list.items[@as(usize, @intCast(index))];
         }
     };
 }
@@ -70,23 +95,23 @@ pub fn evalBinOpExpr(expr: *const ast.BinOpExpr, env: *venv.Env) EvalError!ast.L
         .Add => switch (lhs) {
             .Int => |l| switch (rhs) {
                 .Int => |r| ast.Lit {.Int = l + r},
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             },
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
         },
         .Sub => switch (lhs) {
             .Int => |l| switch (rhs) {
                 .Int => |r| ast.Lit {.Int = l - r},
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             },
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
         },
         .Mul => switch (lhs) {
             .Int => |l| switch (rhs) {
                 .Int => |r| ast.Lit {.Int = l * r},
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             },
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
         },
         .Div => switch (lhs) {
             .Int => |l| switch (rhs) {
@@ -94,64 +119,68 @@ pub fn evalBinOpExpr(expr: *const ast.BinOpExpr, env: *venv.Env) EvalError!ast.L
                     if (r == 0) return ArithmeticError.DivisionByZero;
                     return ast.Lit {.Int = @divFloor(l, r)};
                 },
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             },
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
         },
         .And => switch (lhs) {
             .Bool => |l| switch (rhs) {
                 .Bool => |r| ast.Lit {.Bool = l and r},
-                .Int, .Callable, .Void => TypeError.MismatchedType,
+                .Int, .Callable, .Void, .List => TypeError.MismatchedType,
             },
-            .Int, .Callable, .Void => TypeError.MismatchedType,
+            .Int, .Callable, .Void, .List => TypeError.MismatchedType,
         },
         .Or => switch (lhs) {
             .Bool => |l| switch (rhs) {
                 .Bool => |r| ast.Lit {.Bool = l or r},
-                .Int, .Callable, .Void => TypeError.MismatchedType,
+                .Int, .Callable, .Void, .List => TypeError.MismatchedType,
             },
-            .Int, .Callable, .Void => TypeError.MismatchedType,
+            .Int, .Callable, .Void, .List => TypeError.MismatchedType,
         },
         .Eq => switch (lhs) {
             .Bool => |l| switch (rhs) {
                 .Bool => |r| ast.Lit {.Bool = l == r},
-                .Int, .Callable, .Void => ast.Lit {.Bool = false},
+                .Int, .Callable, .Void, .List => ast.Lit {.Bool = false},
             },
             .Int => |l| switch (rhs) {
-                .Bool, .Callable, .Void => ast.Lit {.Bool = false},
+                .Bool, .Callable, .Void, .List => ast.Lit {.Bool = false},
                 .Int => |r| ast.Lit {.Bool = l == r}
             },
             .Callable => |l| switch (rhs) {
                 .Callable => |r| ast.Lit {.Bool = std.meta.eql(l, r)},
-                .Int, .Bool, .Void => ast.Lit {.Bool = false},
+                .Int, .Bool, .Void, .List => ast.Lit {.Bool = false},
+            },
+            .List => |l| switch (rhs) {
+                .Int, .Bool, .Callable, .Void => ast.Lit {.Bool = false},
+                .List => |r| ast.Lit {.Bool = std.meta.eql(l.items, r.items)},
             },
             .Void => ast.Lit {.Bool = false},
         },
         .Lt => switch (lhs) {
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l < r}
             }
         },
         .Gt => switch (lhs) {
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l > r}
             }
         },
         .Lte => switch (lhs) {
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l <= r}
             }
         },
         .Gte => switch (lhs) {
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
             .Int => |l| switch (rhs) {
-                .Bool, .Callable, .Void => TypeError.MismatchedType,
+                .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
                 .Int => |r| ast.Lit {.Bool = l >= r}
             }
         },
@@ -166,12 +195,12 @@ pub fn evalUnOpExpr(expr: *const ast.UnOpExpr, env: *venv.Env) EvalError!ast.Lit
     // Evaluate operator
     return switch (expr.op) {
         .Not => switch (lit) {
-            .Int, .Callable, .Void => TypeError.MismatchedType,
+            .Int, .Callable, .Void, .List => TypeError.MismatchedType,
             .Bool => |val| ast.Lit { .Bool = !val },
         },
         .Neg => switch (lit) {
             .Int => |val| ast.Lit { .Int = -val },
-            .Bool, .Callable, .Void => TypeError.MismatchedType,
+            .Bool, .Callable, .Void, .List => TypeError.MismatchedType,
         },
     };
 }
@@ -187,11 +216,16 @@ pub fn evalAssignExpr(expr: *const ast.AssignExpr, env: *venv.Env) EvalError!ast
     };
 
     // Evaluate right-hand side
-    const rhs: ast.Lit = try evalExpr(expr.rhs, env);
+    var rhs: ast.Lit = try evalExpr(expr.rhs, env);
 
-    // Make sure that right-hand side is NOT a callable
+    // Treat for errors (prevent callables, or make reference)
+    // also prevent extra references from callexpressions
     switch (rhs) {
         .Callable => return EvalError.InvalidUpcall,
+        .List => |lst| switch (expr.rhs.*) {
+            .CallExpr => {},
+            else => rhs = ast.Lit {.List = lst.makeReference()}
+        },
         else => {},
     }
 
@@ -199,8 +233,46 @@ pub fn evalAssignExpr(expr: *const ast.AssignExpr, env: *venv.Env) EvalError!ast
     switch (lval) {
         .Var => |id| {
             if (!env.isDeclaredGlobal(id)) return EvalError.UndefinedVariable;
+
+            // Destroy existing value
+            switch (env.lookup(id) orelse unreachable) {
+                .Undefined => {},
+                .Var => |v| switch (v) {
+                    .List => |l| l.destroyAll(env.allocator),
+                    .Callable => |c| c.destroyAll(env.allocator),
+                    .Int, .Bool, .Void => {}
+                }
+            }
+
+            // Insert new value
             env.insertScoping(id, venv.ObjectVal {.Var = rhs});
-        }
+        },
+        .ListIndex => |lidx| {
+
+            // Make sure that left-hand side is a list
+            const lst: ast.List = switch (try evalExpr(lidx.id, env)) {
+                .List => |l| l.*,
+                .Int, .Bool, .Void, .Callable => return EvalError.NotList
+            };
+
+            // Evaluate index
+            const idx: i64 = switch (try evalExpr(lidx.idx, env)) {
+                .Int => |i| i,
+                .Bool, .Void, .Callable, .List => return EvalError.MismatchedType,
+            };
+
+            // Bounds checking
+            if (idx < 0 or idx >= lst.len) return EvalError.IndexOutOfBounds;
+
+            // Destroy existing value
+            switch (lst.items[@as(usize, @intCast(idx))]) {
+                .List, .Callable => lst.items[@as(usize, @intCast(idx))].destroyAll(env.allocator),
+                .Int, .Bool, .Void => {}
+            }
+
+            // Perform assignment
+            lst.items[@as(usize, @intCast(idx))] = rhs;
+        },
     }
 
     return rhs;
@@ -211,7 +283,7 @@ pub fn evalCallExpr(expr: *const ast.CallExpr, env: *venv.Env) EvalError!ast.Lit
     // Evaluate identifier
     const callable: ast.Callable = switch(try evalExpr(expr.id, env)) {
         .Callable => |fun| fun,
-        .Int, .Bool, .Void => return EvalError.NotCallable,
+        .Int, .Bool, .Void, .List => return EvalError.NotCallable,
     };
 
     // Create a scoped environment based on function closure
@@ -223,7 +295,11 @@ pub fn evalCallExpr(expr: *const ast.CallExpr, env: *venv.Env) EvalError!ast.Lit
     for (callable.params, expr.args) |id, arg| {
 
         // NOTE: Evaluating in current environment, not in closure or scoped
-        const r: ast.Lit = try evalExpr(arg, env);
+        var r: ast.Lit = try evalExpr(arg, env);
+        switch (r) {
+            .List => |l| r = ast.Lit {.List = l.makeReference()},
+            else => {}
+        }
 
         // Bind in environment directly
         // NOTE: Can also declare and then insertScoped
@@ -257,8 +333,9 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
     switch (statement) {
         .ExprStmt => |expr| {
 
-            // Evaluate and return underlying expression
-            _ = try evalExpr(expr, env);
+            // Evaluate and destroy underlying expression
+            var lit: ast.Lit = try evalExpr(expr, env);
+            lit.destroyAll(env.allocator);
             return StmtReturn {.NoReturn = {}};
         },
         .DeclareStmt => |exprs| {
@@ -282,7 +359,8 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
                 // Evalute left-hand side lval to an identifier
                 // TODO: This can also be array indexing, object field/property, etc.
                 const id: []const u8 = switch (try lhs) {
-                    .Var => |id| id
+                    .Var => |id| id,
+                    .ListIndex => return EvalError.NotIdentifier
                 };
 
                 // Do error checking
@@ -334,7 +412,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
 
             // Check condition
             const res: bool = switch (try evalExpr(stmt.cond, env)) {
-                .Int, .Callable, .Void => return TypeError.MismatchedType,
+                .Int, .Callable, .Void, .List => return TypeError.MismatchedType,
                 .Bool => |b| b,
             };
 
@@ -357,7 +435,7 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
 
                 // Check condition
                 const res: bool = switch (try evalExpr(stmt.cond, env)) {
-                    .Int, .Callable, .Void => return TypeError.MismatchedType,
+                    .Int, .Callable, .Void, .List => return TypeError.MismatchedType,
                     .Bool => |b| b,
                 };
 
@@ -382,10 +460,15 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
         .ContinueStmt => return StmtReturn {.Continue = {}},
         .ReturnStmt => |expr| {
             // Evaluate expression and make sure its not a Callable
+            // If expr is a CallExpr, we do not make extra list reference
             const res: ast.Lit = try evalExpr(expr, env);
             return switch (res) {
                 .Callable => EvalError.InvalidUpcall,
-                else => StmtReturn {.Return = try evalExpr(expr, env)},
+                .List => |l| switch (expr.*) {
+                    .CallExpr => StmtReturn {.Return = res},
+                    else => StmtReturn {.Return = ast.Lit {.List = l.makeReference()}},
+                },
+                else => StmtReturn {.Return = res},
             };
         },
         .FunDefStmt => |stmt| {
@@ -403,6 +486,56 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
 
             return StmtReturn {.NoReturn = {}};
         },
+        .MakeStmt => |exprs| {
+
+            for (exprs) |expr| {
+
+                // Make sure each expression is a ListIndexExpr
+                const obj: ast.ListIndex = switch (expr.*) {
+                    .Lval => |lval| switch (lval) {
+                        .Var => return EvalError.NotList,
+                        .ListIndex => |li| li,
+                    },
+                    else => return EvalError.NotList
+                };
+
+                // Make sure that id is a Var
+                const id: ast.Var = switch (obj.id.*) {
+                    .Lval => |lv| switch (lv) {
+                        .Var => |v| v,
+                        .ListIndex => return EvalError.NotIdentifier,
+                    },
+                    else => return EvalError.NotIdentifier
+                };
+
+                // Do error checking
+                if (env.isDeclaredLocal(id)) return EvalError.IdentifierAlreadyDeclared;
+
+                // Evaluate index (size)
+                const size: i64 = switch (try evalExpr(obj.idx, env)) {
+                    .Int => |i| i,
+                    .Bool, .Callable, .Void, .List => return EvalError.MismatchedType,
+                };
+
+                // Do size checking
+                if (size < 0) return EvalError.InvalidSize;
+
+                // Add identifier to environment
+                const items_ptr = env.allocator.alloc(ast.Lit, @as(usize, @intCast(size))) catch unreachable;
+                const ptr = env.allocator.create(ast.List) catch unreachable;
+
+                ptr.* = ast.List {
+                    .len = @as(usize, @intCast(size)),
+                    .items = items_ptr,
+                };
+                env.insert(id, venv.ObjectVal {.Var = ast.Lit {.List = ptr}});
+
+                // Initialize with void values..
+                for (items_ptr) |*item| item.* = ast.Lit {.Void = {}};
+            }
+
+            return StmtReturn {.NoReturn = {}};
+        }
     }
 
     unreachable;

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -358,9 +358,8 @@ pub fn evalStmt(statement: ast.Stmt, env: *venv.Env) EvalError!StmtReturn {
     switch (statement) {
         .ExprStmt => |expr| {
 
-            // Evaluate and destroy underlying expression
-            var lit: ast.Lit = try evalExpr(expr, env);
-            lit.destroyAll(env.allocator);
+            // Evaluate the underlying expression
+            _ = try evalExpr(expr, env);
             return StmtReturn {.NoReturn = {}};
         },
         .DeclareStmt => |exprs| {

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -57,7 +57,7 @@ fn operator_from_string(str: []const u8) token.Token {
 }
 
 fn is_keyword(chars: []const u8) bool {
-    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function"}, chars);
+    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function", "make"}, chars);
 }
 
 fn keyword_from_string(str: []const u8) token.Token {
@@ -70,6 +70,7 @@ fn keyword_from_string(str: []const u8) token.Token {
     if (std.mem.eql(u8, str, "continue")) return token.Token {.CONTINUE = {}};
     if (std.mem.eql(u8, str, "return")) return token.Token {.RETURN = {}};
     if (std.mem.eql(u8, str, "function")) return token.Token {.FUN = {}};
+    if (std.mem.eql(u8, str, "make")) return token.Token {.MAKE = {}};
     unreachable;
 }
 
@@ -286,7 +287,7 @@ pub const Lexer = struct {
 
                 // Allow line breaks before statement keywords
                 // NOTE: Including single-word statements here to get LB error on "break x"
-                .DECLARE, .PRINT, .IF, .ELSE, .WHILE, .BREAK, .CONTINUE, .RETURN, .FUN => {
+                .DECLARE, .PRINT, .IF, .ELSE, .WHILE, .BREAK, .CONTINUE, .RETURN, .FUN, .MAKE => {
                     self.pushLB(&res);
                     res.append(tok) catch unreachable;
                     isStatement = true;

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -14,7 +14,7 @@ fn createLU(comptime chars: []const u8) [256]bool {
 const is_numeric_digit: [256]bool = createLU("0123456789");
 const is_real_digit: [256]bool = createLU(".0123456789");
 const is_whitespace_digit: [256]bool = createLU(" \t\r");
-const is_operator_digit: [256]bool = createLU("+-/*|&()[]{}=!<>\n,");
+const is_operator_digit: [256]bool = createLU("+-/*|&()[]{}=!<>\n,.");
 const is_ident_digit: [256]bool = createLU(
     "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 );
@@ -26,7 +26,7 @@ fn contains(arr: []const []const u8, item: []const u8) bool {
 
 fn is_operator(chars: []const u8) bool {
     return contains(
-        &[_][]const u8 { "\n", "+", "-", "*", "/", "!", "||", "&&", "==", "=", "(", ")", "[", "]", "{", "}", "<", ">", "<=", ">=", ","},
+        &[_][]const u8 { "\n", "+", "-", "*", "/", "!", "||", "&&", "==", "=", "(", ")", "[", "]", "{", "}", "<", ">", "<=", ">=", ",", "."},
         chars
     );
 }
@@ -52,6 +52,7 @@ fn operator_from_string(str: []const u8) token.Token {
     if (std.mem.eql(u8, str, "<=")) return token.Token {.LTE = {}};
     if (std.mem.eql(u8, str, ">=")) return token.Token {.GTE = {}};
     if (std.mem.eql(u8, str, ",")) return token.Token {.COMMA = {}};
+    if (std.mem.eql(u8, str, ".")) return token.Token {.DOT = {}};
     if (std.mem.eql(u8, str, "\n")) return token.Token {.LB = {}};
     unreachable;
 }

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -57,7 +57,7 @@ fn operator_from_string(str: []const u8) token.Token {
 }
 
 fn is_keyword(chars: []const u8) bool {
-    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function", "make"}, chars);
+    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function"}, chars);
 }
 
 fn keyword_from_string(str: []const u8) token.Token {
@@ -70,7 +70,6 @@ fn keyword_from_string(str: []const u8) token.Token {
     if (std.mem.eql(u8, str, "continue")) return token.Token {.CONTINUE = {}};
     if (std.mem.eql(u8, str, "return")) return token.Token {.RETURN = {}};
     if (std.mem.eql(u8, str, "function")) return token.Token {.FUN = {}};
-    if (std.mem.eql(u8, str, "make")) return token.Token {.MAKE = {}};
     unreachable;
 }
 
@@ -287,7 +286,7 @@ pub const Lexer = struct {
 
                 // Allow line breaks before statement keywords
                 // NOTE: Including single-word statements here to get LB error on "break x"
-                .DECLARE, .PRINT, .IF, .ELSE, .WHILE, .BREAK, .CONTINUE, .RETURN, .FUN, .MAKE => {
+                .DECLARE, .PRINT, .IF, .ELSE, .WHILE, .BREAK, .CONTINUE, .RETURN, .FUN => {
                     self.pushLB(&res);
                     res.append(tok) catch unreachable;
                     isStatement = true;

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -192,8 +192,7 @@ pub const Parser = struct {
                             }
                         }};
                     },
-                    // TODO: Allow other kinds of post-fix operators
-                    // like obj.property and arr[idx]
+
                     else => unreachable,
                 };
 
@@ -225,6 +224,10 @@ pub const Parser = struct {
                         .lhs = lhs,
                         .rhs = rhs
                     }},
+                    .DOT => ast.Expr {.Lval = ast.Lval {.PropertyAccess = ast.PropertyAccess {
+                        .lhs = lhs,
+                        .prop = rhs
+                    }}},
                     else => ast.Expr {.BinOpExpr = ast.BinOpExpr {
                         .lhs = lhs,
                         .op = ast.BinOp.from_token(op_token).?,

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -279,22 +279,6 @@ pub const Parser = struct {
                 try self.expectTokenOrEOF(Token {.LB = {}});
                 break :blk ast.Stmt {.PrintStmt = acc.toOwnedSlice() catch unreachable};
             },
-            .MAKE => {
-                try self.expectToken(Token {.MAKE = {}});
-
-                var acc: ArrayList(*ast.Expr) = .init(self.allocator);
-                defer acc.deinit();
-                errdefer for (acc.items) |expr| expr.destroyAll(self.allocator);
-
-                acc.append(try self.parseExpr()) catch unreachable;
-                while (std.meta.eql(self.peekToken(), Token {.COMMA = {}})) {
-                    try self.expectToken(Token {.COMMA = {}});
-                    acc.append(try self.parseExpr()) catch unreachable;
-                }
-
-                try self.expectTokenOrEOF(Token {.LB = {}});
-                break :blk ast.Stmt {.MakeStmt = acc.toOwnedSlice() catch unreachable};
-            },
             .DECLARE => {
                 try self.expectToken(Token {.DECLARE = {}});
 

--- a/src/tests/interpreter.zig
+++ b/src/tests/interpreter.zig
@@ -1410,7 +1410,7 @@ test "make statement test" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
@@ -1446,7 +1446,7 @@ test "multi make statement test" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "list"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
@@ -1502,7 +1502,7 @@ test "list mutation" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 3}}
@@ -1551,7 +1551,7 @@ test "list referencing" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 3}}
@@ -1608,7 +1608,7 @@ test "list referencing 2" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 3}}
@@ -1665,7 +1665,7 @@ test "list overwrite" {
     // Prepare procedure
     const proc: ast.Proc = ast.Proc {.stmts = &[_]ast.Stmt {
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 3}}
@@ -1711,7 +1711,7 @@ test "list function mutation" {
             }}
         }}},
 
-        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "mylist"}},
                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
@@ -1764,7 +1764,7 @@ test "list function return" {
             .id = "f",
             .params = &[_]ast.Var {},
             .body = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-                ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+                ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
                     &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                         .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                         .idx = &ast.Expr {.Lit = ast.Lit {.Int = 10}}
@@ -1825,7 +1825,7 @@ test "nested list function return" {
                     .id = "g",
                     .params = &[_]ast.Var {},
                     .body = ast.Stmt {.BlockStmt = &[_]ast.Stmt {
-                        ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+                        ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
                             &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
                                 .id = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
                                 .idx = &ast.Expr {.Lit = ast.Lit {.Int = 10}}

--- a/src/tests/lexer.zig
+++ b/src/tests/lexer.zig
@@ -1566,3 +1566,71 @@ test "multiline multi make" {
 
     try std.testing.expectEqualDeep(expected, tokens.items);
 }
+
+test "property access" {
+    const input =
+        \\mylist.size
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.IDENT = "mylist"},
+        Token {.DOT = {}},
+        Token {.IDENT = "size"},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}
+
+test "multi property access" {
+    const input =
+        \\obj.prop1.prop2
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.IDENT = "obj"},
+        Token {.DOT = {}},
+        Token {.IDENT = "prop1"},
+        Token {.DOT = {}},
+        Token {.IDENT = "prop2"},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}
+
+test "multiline property access not allowed" {
+    const input =
+        \\obj
+        \\  .prop1
+        \\  .prop2
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.IDENT = "obj"},
+        Token {.LB = {}},
+        Token {.DOT = {}},
+        Token {.IDENT = "prop1"},
+        Token {.LB = {}},
+        Token {.DOT = {}},
+        Token {.IDENT = "prop2"},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}

--- a/src/tests/lexer.zig
+++ b/src/tests/lexer.zig
@@ -1516,7 +1516,7 @@ test "inline simple function definition with return" {
 
 test "single make" {
     const input =
-        \\make list[10]
+        \\declare list[10]
     ;
 
     var lx = lexer.Lexer.new(input, std.testing.allocator);
@@ -1525,7 +1525,7 @@ test "single make" {
     defer tokens.deinit();
 
     const expected: []const Token = &[_]Token{
-        Token {.MAKE = {}},
+        Token {.DECLARE = {}},
         Token {.IDENT = "list"},
         Token {.LBRACK = {}},
         Token {.INTLIT = 10},
@@ -1538,7 +1538,7 @@ test "single make" {
 
 test "multiline multi make" {
     const input =
-        \\make list[10], anotherlist[5]
+        \\declare list[10], anotherlist[5]
         \\print 10
     ;
 
@@ -1548,7 +1548,7 @@ test "multiline multi make" {
     defer tokens.deinit();
 
     const expected: []const Token = &[_]Token{
-        Token {.MAKE = {}},
+        Token {.DECLARE = {}},
         Token {.IDENT = "list"},
         Token {.LBRACK = {}},
         Token {.INTLIT = 10},

--- a/src/tests/lexer.zig
+++ b/src/tests/lexer.zig
@@ -1513,3 +1513,56 @@ test "inline simple function definition with return" {
 
     try std.testing.expectEqualDeep(expected, tokens.items);
 }
+
+test "single make" {
+    const input =
+        \\make list[10]
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.MAKE = {}},
+        Token {.IDENT = "list"},
+        Token {.LBRACK = {}},
+        Token {.INTLIT = 10},
+        Token {.RBRACK = {}},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}
+
+test "multiline multi make" {
+    const input =
+        \\make list[10], anotherlist[5]
+        \\print 10
+    ;
+
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.MAKE = {}},
+        Token {.IDENT = "list"},
+        Token {.LBRACK = {}},
+        Token {.INTLIT = 10},
+        Token {.RBRACK = {}},
+        Token {.COMMA = {}},
+        Token {.IDENT = "anotherlist"},
+        Token {.LBRACK = {}},
+        Token {.INTLIT = 5},
+        Token {.RBRACK = {}},
+        Token {.LB = {}},
+        Token {.PRINT = {}},
+        Token {.INTLIT = 10},
+        Token {.EOF = {}}
+    };
+
+    try std.testing.expectEqualDeep(expected, tokens.items);
+}

--- a/src/tests/parser.zig
+++ b/src/tests/parser.zig
@@ -1877,7 +1877,7 @@ test "function definition no body 2" {
 test "make statement" {
 
     var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
-    try tokens.append(Token {.MAKE = {}});
+    try tokens.append(Token {.DECLARE = {}});
     try tokens.append(Token {.IDENT = "list"});
     try tokens.append(Token {.LBRACK = {}});
     try tokens.append(Token {.INTLIT = 1});
@@ -1887,7 +1887,7 @@ test "make statement" {
 
     var prs: parser.Parser = .new(tokens, std.testing.allocator);
 
-    const expect: ast.Stmt = ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+    const expect: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
         &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
             .id = &ast.Expr {.Lval = ast.Lval {.Var = "list"}},
             .idx = &ast.Expr {.Lit = ast.Lit {.Int = 1}}
@@ -1903,7 +1903,7 @@ test "make statement" {
 test "multi make statement" {
 
     var tokens: std.ArrayList(Token) = std.ArrayList(Token).init(std.testing.allocator);
-    try tokens.append(Token {.MAKE = {}});
+    try tokens.append(Token {.DECLARE = {}});
     try tokens.append(Token {.IDENT = "list"});
     try tokens.append(Token {.LBRACK = {}});
     try tokens.append(Token {.INTLIT = 1});
@@ -1918,7 +1918,7 @@ test "multi make statement" {
 
     var prs: parser.Parser = .new(tokens, std.testing.allocator);
 
-    const expect: ast.Stmt = ast.Stmt {.MakeStmt = &[_]*const ast.Expr {
+    const expect: ast.Stmt = ast.Stmt {.DeclareStmt = &[_]*const ast.Expr {
         &ast.Expr {.Lval = ast.Lval {.ListIndex = ast.ListIndex {
             .id = &ast.Expr {.Lval = ast.Lval {.Var = "list"}},
             .idx = &ast.Expr {.Lit = ast.Lit {.Int = 1}}

--- a/src/tests/parser.zig
+++ b/src/tests/parser.zig
@@ -2201,3 +2201,67 @@ test "declare multi list with initialization" {
 
     try std.testing.expectEqualDeep(expect, actual);
 }
+
+test "property access" {
+
+    var tokens: std.ArrayList(Token) = .init(std.testing.allocator);
+    defer tokens.deinit();
+
+    try tokens.append(Token {.IDENT = "lst"});
+    try tokens.append(Token {.DOT = {}});
+    try tokens.append(Token {.IDENT = "size"});
+    try tokens.append(Token {.EOF = {}});
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const result: *ast.Expr = try prs.parseExpr();
+    defer result.destroyAll(std.testing.allocator);
+
+
+    const expect: ast.Expr = ast.Expr { .Lval = ast.Lval {
+        .PropertyAccess = ast.PropertyAccess {
+            .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "lst"}},
+            .prop = &ast.Expr {.Lval = ast.Lval {.Var = "size"}}
+        }}
+    };
+
+    try std.testing.expectEqualDeep(expect, result.*);
+}
+
+test "multi property access" {
+
+    var tokens: std.ArrayList(Token) = .init(std.testing.allocator);
+    defer tokens.deinit();
+
+    try tokens.append(Token {.IDENT = "obj"});
+    try tokens.append(Token {.DOT = {}});
+    try tokens.append(Token {.IDENT = "prop1"});
+    try tokens.append(Token {.DOT = {}});
+    try tokens.append(Token {.IDENT = "prop2"});
+    try tokens.append(Token {.DOT = {}});
+    try tokens.append(Token {.IDENT = "prop3"});
+    try tokens.append(Token {.EOF = {}});
+    var prs: parser.Parser = .new(tokens, std.testing.allocator);
+
+    const result: *ast.Expr = try prs.parseExpr();
+    defer result.destroyAll(std.testing.allocator);
+
+
+    const expect: ast.Expr = ast.Expr { .Lval = ast.Lval {
+        .PropertyAccess = ast.PropertyAccess {
+            .lhs = &ast.Expr {.Lval = ast.Lval {
+                .PropertyAccess = ast.PropertyAccess {
+                    .lhs = &ast.Expr {.Lval = ast.Lval {
+                        .PropertyAccess = ast.PropertyAccess {
+                            .lhs = &ast.Expr {.Lval = ast.Lval {.Var = "obj"}},
+                            .prop = &ast.Expr {.Lval = ast.Lval {.Var = "prop1"}}
+                        }
+                    }},
+                    .prop = &ast.Expr {.Lval = ast.Lval {.Var = "prop2"}}
+                }
+            }},
+            .prop = &ast.Expr {.Lval = ast.Lval {.Var = "prop3"}}
+        }}
+    };
+
+    try std.testing.expectEqualDeep(expect, result.*);
+}

--- a/src/token.zig
+++ b/src/token.zig
@@ -34,6 +34,7 @@ pub const TokenType: type = enum {
     FUN,
     LB,
     COMMA,
+    DOT,
     EOF,
     ERROR,
     ILLEGAL
@@ -84,6 +85,7 @@ pub const Token: type = union(TokenType) {
     // Utility
     LB: void,
     COMMA: void,
+    DOT: void,
     EOF: void,
     ERROR: []const u8,
     ILLEGAL: u8,
@@ -100,6 +102,7 @@ pub const Token: type = union(TokenType) {
             .EOF      => try writer.print("[EOF     ]:", .{}),
             .LB       => try writer.print("[LB      ]:", .{}),
             .COMMA    => try writer.print("[COMMA   ]:", .{}),
+            .DOT      => try writer.print("[DOT     ]:", .{}),
             .ERROR    => |val| try writer.print("[ERROR   ]: {s}", .{val}),
             .ILLEGAL  => |val| try writer.print("[ILLEGAL ]: {c}", .{val}),
             .LPAREN   => try writer.print("[LPAREN  ]:", .{}),
@@ -155,6 +158,8 @@ pub const Token: type = union(TokenType) {
             .PLUS, .MINUS => InfixPrecedence {.left = 9, .right = 10},
             .MUL, .DIV    => InfixPrecedence {.left = 11, .right = 12},
 
+            .DOT => InfixPrecedence {.left = 19, .right = 20},
+
             // Some are not operators
             else => null
         };
@@ -169,7 +174,6 @@ pub const Token: type = union(TokenType) {
 
     pub fn getPostfixPrecedence(self: Token) ?u8 {
         return switch(self) {
-            // TODO: Implement arr[idx] and object.field operators
             .LPAREN => 15,
             .LBRACK => 17,
             else => null

--- a/src/token.zig
+++ b/src/token.zig
@@ -24,7 +24,6 @@ pub const TokenType: type = enum {
     LCURLY,
     RCURLY,
     DECLARE,
-    MAKE,
     PRINT,
     IF,
     ELSE,
@@ -73,7 +72,6 @@ pub const Token: type = union(TokenType) {
 
     // Keywords
     DECLARE: void,
-    MAKE: void,
     PRINT: void,
     IF: void,
     ELSE: void,
@@ -124,7 +122,6 @@ pub const Token: type = union(TokenType) {
             .LTE      => try writer.print("[LTE     ]:", .{}),
             .GTE      => try writer.print("[GTE     ]:", .{}),
             .DECLARE  => try writer.print("[DECLARE ]:", .{}),
-            .MAKE     => try writer.print("[MAKE    ]:", .{}),
             .PRINT    => try writer.print("[PRINT   ]:", .{}),
             .IF       => try writer.print("[IF      ]:", .{}),
             .ELSE     => try writer.print("[ELSE    ]:", .{}),

--- a/src/token.zig
+++ b/src/token.zig
@@ -24,6 +24,7 @@ pub const TokenType: type = enum {
     LCURLY,
     RCURLY,
     DECLARE,
+    MAKE,
     PRINT,
     IF,
     ELSE,
@@ -72,6 +73,7 @@ pub const Token: type = union(TokenType) {
 
     // Keywords
     DECLARE: void,
+    MAKE: void,
     PRINT: void,
     IF: void,
     ELSE: void,
@@ -122,6 +124,7 @@ pub const Token: type = union(TokenType) {
             .LTE      => try writer.print("[LTE     ]:", .{}),
             .GTE      => try writer.print("[GTE     ]:", .{}),
             .DECLARE  => try writer.print("[DECLARE ]:", .{}),
+            .MAKE     => try writer.print("[MAKE    ]:", .{}),
             .PRINT    => try writer.print("[PRINT   ]:", .{}),
             .IF       => try writer.print("[IF      ]:", .{}),
             .ELSE     => try writer.print("[ELSE    ]:", .{}),
@@ -171,6 +174,7 @@ pub const Token: type = union(TokenType) {
         return switch(self) {
             // TODO: Implement arr[idx] and object.field operators
             .LPAREN => 15,
+            .LBRACK => 17,
             else => null
         };
     }


### PR DESCRIPTION
Implemented list declarations using `declare list[size]` syntax, allowing initialization with `declare list[size] = val` syntax.
Added `.size` property access on lists.