### PR TITLE
25 type casting

### DIFF
--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -59,7 +59,7 @@ fn operator_from_string(str: []const u8) token.Token {
 }
 
 fn is_keyword(chars: []const u8) bool {
-    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function", "and", "or"}, chars);
+    return contains(&[_][]const u8 {"declare", "print", "if", "else", "while", "break", "continue", "return", "function", "and", "or", "as", "Int", "Float", "Bool"}, chars);
 }
 
 fn keyword_from_string(str: []const u8) token.Token {
@@ -74,6 +74,10 @@ fn keyword_from_string(str: []const u8) token.Token {
     if (std.mem.eql(u8, str, "function")) return token.Token {.FUN = {}};
     if (std.mem.eql(u8, str, "and")) return token.Token {.AND = {}};
     if (std.mem.eql(u8, str, "or")) return token.Token {.OR = {}};
+    if (std.mem.eql(u8, str, "as")) return token.Token {.AS = {}};
+    if (std.mem.eql(u8, str, "Int")) return token.Token {.INT = {}};
+    if (std.mem.eql(u8, str, "Float")) return token.Token {.FLOAT = {}};
+    if (std.mem.eql(u8, str, "Bool")) return token.Token {.BOOL = {}};
     unreachable;
 }
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -106,6 +106,18 @@ pub const Parser = struct {
                 lhs = self.allocator.create(ast.Expr) catch unreachable;
                 lhs.* = ast.Expr { .Lval = ast.Lval {.Var = val}};
             },
+            .INT => {
+                lhs = self.allocator.create(ast.Expr) catch unreachable;
+                lhs.* = ast.Expr {.Lit = ast.Lit {.Type = .Int}};
+            },
+            .FLOAT => {
+                lhs = self.allocator.create(ast.Expr) catch unreachable;
+                lhs.* = ast.Expr {.Lit = ast.Lit {.Type = .Float}};
+            },
+            .BOOL => {
+                lhs = self.allocator.create(ast.Expr) catch unreachable;
+                lhs.* = ast.Expr {.Lit = ast.Lit {.Type = .Bool}};
+            },
 
             // Unary operators
             .MINUS, .NOT => {
@@ -269,6 +281,10 @@ pub const Parser = struct {
                         .lhs = lhs,
                         .prop = rhs
                     }}},
+                    .AS => ast.Expr {.AsExpr = ast.AsExpr {
+                        .lhs = lhs,
+                        .as = rhs
+                    }},
                     else => ast.Expr {.BinOpExpr = ast.BinOpExpr {
                         .lhs = lhs,
                         .op = ast.BinOp.from_token(op_token).?,

--- a/src/tests/interpreter.zig
+++ b/src/tests/interpreter.zig
@@ -2723,3 +2723,212 @@ test "callable in list immediate" {
         interpreter.EvalError.InvalidUpcall
     );
 }
+
+test "type conversion int - bool" {
+    // Prepare environment
+    var env = venv.Env.new(std.testing.allocator);
+    defer env.deinit();
+
+    // Test different cases
+    const e1: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e1, &env),
+        ast.Lit {.Bool = true}
+    );
+    const e2: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = 0}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e2, &env),
+        ast.Lit {.Bool = false}
+    );
+    const e3: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Bool = true}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e3, &env),
+        ast.Lit {.Int = 1}
+    );
+    const e4: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Bool = false}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e4, &env),
+        ast.Lit {.Int = 0}
+    );
+    const e5: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = 2}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e5, &env),
+        ast.Lit {.Bool = true}
+    );
+    const e6: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = -124}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e6, &env),
+        ast.Lit {.Bool = true}
+    );
+    const e7: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = -(0)}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e7, &env),
+        ast.Lit {.Bool = false}
+    );
+}
+
+test "type conversion float - bool" {
+    // Prepare environment
+    var env = venv.Env.new(std.testing.allocator);
+    defer env.deinit();
+
+    // Test different cases
+    const e1: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 1.0}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e1, &env),
+        ast.Lit {.Bool = true}
+    );
+    const e2: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 0.0}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e2, &env),
+        ast.Lit {.Bool = false}
+    );
+    const e3: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Bool = true}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Float}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e3, &env),
+        ast.Lit {.Float = 1.0}
+    );
+    const e4: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Bool = false}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Float}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e4, &env),
+        ast.Lit {.Float = 0.0}
+    );
+    const e5: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 2.00203}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e5, &env),
+        ast.Lit {.Bool = true}
+    );
+    const e6: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = -1.3232042}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e6, &env),
+        ast.Lit {.Bool = true}
+    );
+    const e7: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = -(0.0)}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e7, &env),
+        ast.Lit {.Bool = false}
+    );
+    const e8: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 0.000001}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Bool}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e8, &env),
+        ast.Lit {.Bool = true}
+    );
+}
+
+
+test "type conversion int - float" {
+    // Prepare environment
+    var env = venv.Env.new(std.testing.allocator);
+    defer env.deinit();
+
+    // Test different cases
+    const e1: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 1.0}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e1, &env),
+        ast.Lit {.Int = 1}
+    );
+    const e2: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 0.0}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e2, &env),
+        ast.Lit {.Int = 0}
+    );
+    const e3: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = 1}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Float}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e3, &env),
+        ast.Lit {.Float = 1.0}
+    );
+    const e4: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Int = 0}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Float}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e4, &env),
+        ast.Lit {.Float = 0.0}
+    );
+    const e5: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 2.00203}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e5, &env),
+        ast.Lit {.Int = 2}
+    );
+    const e6: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = -1.3232042}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e6, &env),
+        ast.Lit {.Int = -1}
+    );
+    const e7: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = -(0.0)}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e7, &env),
+        ast.Lit {.Int = 0}
+    );
+    const e8: ast.Expr = ast.Expr {.AsExpr = ast.AsExpr {
+        .lhs = &ast.Expr {.Lit = ast.Lit {.Float = 0.000001}},
+        .as = &ast.Expr {.Lit = ast.Lit {.Type = .Int}}
+    }};
+    try std.testing.expectEqualDeep(
+        try interpreter.evalExpr(&e8, &env),
+        ast.Lit {.Int = 0}
+    );
+}

--- a/src/tests/lexer.zig
+++ b/src/tests/lexer.zig
@@ -1800,3 +1800,25 @@ test "booleans alternative" {
 
     try expect(tokens_eql(tokens.items, expected));
 }
+
+test "as and type keywords" {
+
+    const input = "true as Int as Float as Bool";
+    var lx = lexer.Lexer.new(input, std.testing.allocator);
+
+    const tokens: std.ArrayList(Token) = lx.lex();
+    defer tokens.deinit();
+
+    const expected: []const Token = &[_]Token{
+        Token {.BOOLLIT = true},
+        Token {.AS = {}},
+        Token {.INT = {}},
+        Token {.AS = {}},
+        Token {.FLOAT = {}},
+        Token {.AS = {}},
+        Token {.BOOL = {}},
+        Token {.EOF = {}}
+    };
+
+    try expect(tokens_eql(tokens.items, expected));
+}

--- a/src/token.zig
+++ b/src/token.zig
@@ -33,6 +33,10 @@ pub const TokenType: type = enum {
     CONTINUE,
     RETURN,
     FUN,
+    INT,
+    FLOAT,
+    BOOL,
+    AS,
     LB,
     COMMA,
     DOT,
@@ -83,6 +87,10 @@ pub const Token: type = union(TokenType) {
     CONTINUE: void,
     RETURN: void,
     FUN: void,
+    INT: void,
+    FLOAT: void,
+    BOOL: void,
+    AS: void,
 
     // Utility
     LB: void,
@@ -135,6 +143,10 @@ pub const Token: type = union(TokenType) {
             .CONTINUE => try writer.print("[CONTINUE]:", .{}),
             .RETURN   => try writer.print("[RETURN  ]:", .{}),
             .FUN      => try writer.print("[FUN     ]:", .{}),
+            .INT      => try writer.print("[INT     ]:", .{}),
+            .FLOAT    => try writer.print("[FLOAT   ]:", .{}),
+            .BOOL     => try writer.print("[BOOL    ]:", .{}),
+            .AS       => try writer.print("[AS      ]:", .{}),
             .INTLIT   => |val| try writer.print("[INTLIT  ]: {}", .{val}),
             .FLOATLIT => |val| try writer.print("[FLOATLIT]: {}", .{val}),
             .BOOLLIT  => |val| try writer.print("[BOOLLIT ]: {}", .{val}),
@@ -162,11 +174,12 @@ pub const Token: type = union(TokenType) {
 
             .DEQ          => InfixPrecedence {.left = 11, .right = 12},
 
+            .AS           => InfixPrecedence {.left = 13, .right = 14},
 
-            .PLUS, .MINUS => InfixPrecedence {.left = 13, .right = 14},
-            .MUL, .DIV    => InfixPrecedence {.left = 15, .right = 16},
+            .PLUS, .MINUS => InfixPrecedence {.left = 15, .right = 16},
+            .MUL, .DIV    => InfixPrecedence {.left = 17, .right = 18},
 
-            .DOT => InfixPrecedence {.left = 23, .right = 24},
+            .DOT => InfixPrecedence {.left = 25, .right = 26},
 
             // Some are not operators
             else => null
@@ -175,15 +188,15 @@ pub const Token: type = union(TokenType) {
 
     pub fn getPrefixPrecedence(self: Token) ?u8 {
         return switch(self) {
-            .MINUS, .NOT => 17,
+            .MINUS, .NOT => 19,
             else => null
         };
     }
 
     pub fn getPostfixPrecedence(self: Token) ?u8 {
         return switch(self) {
-            .LPAREN => 19,
-            .LBRACK => 21,
+            .LPAREN => 21,
+            .LBRACK => 23,
             else => null
         };
     }


### PR DESCRIPTION
Added `as`-expressions which allow to cast value into another type. Added type literals for `Int`, `Float` and `Bool` types.